### PR TITLE
feat(nvr-ui): support XM 40E managed camera truth in the NVR surface

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -602,8 +602,8 @@ function cameraDisplayName(sourceId: string): string {
   if (!key) return "Camera";
   const mounted = mountedCameraRecord(key);
   const mountedLabel = String(
-    mounted?.displayName
-      || mounted?.observed?.displayName
+    mounted?.observed?.displayName
+      || mounted?.displayName
       || mounted?.desired?.displayName
       || "",
   ).trim();
@@ -1625,6 +1625,8 @@ function seedCameraDraftsFromInventory(): void {
   for (const camera of cameraInventory?.mounted || []) {
     const sourceId = String(camera.sourceId || "").trim();
     if (!sourceId) continue;
+    const supportsOverlayText = camera.capabilities?.overlayText === true;
+    const supportsOverlayTimestamp = camera.capabilities?.overlayTimestamp === true;
     const observedServices = camera.observed?.services || {};
     const observedOnvif = serviceEnabled(observedServices.onvif);
     const observedRtsp = serviceEnabled(observedServices.rtsp);
@@ -1634,8 +1636,12 @@ function seedCameraDraftsFromInventory(): void {
     const observed9000 = serviceEnabled(observedServices.proprietary9000);
     const nextDraft: CameraSettingsDraft = {
       displayName: String(camera.desired?.displayName || camera.displayName || camera.observed?.displayName || sourceId).trim() || sourceId,
-      overlayText: String(camera.desired?.overlayText || camera.observed?.overlayText || camera.displayName || camera.observed?.displayName || "").trim(),
-      overlayTimestamp: camera.desired?.overlayTimestamp !== false && camera.observed?.overlayTimestamp !== false,
+      overlayText: supportsOverlayText
+        ? String(camera.desired?.overlayText || camera.observed?.overlayText || camera.displayName || camera.observed?.displayName || "").trim()
+        : "",
+      overlayTimestamp: supportsOverlayTimestamp
+        ? camera.desired?.overlayTimestamp !== false && camera.observed?.overlayTimestamp !== false
+        : false,
       desiredPassword: String(camera.desired?.desiredPassword || "").trim(),
       generatePassword: camera.desired?.generatePassword === true,
       enableOnvif: typeof camera.desired?.hardening?.enableOnvif === "boolean"
@@ -1678,6 +1684,7 @@ async function saveCameraSettings(sourceId: string): Promise<void> {
   const key = String(sourceId || "").trim();
   if (!key) throw new Error("camera source is missing");
   const draft = cameraSettingsDraft(sourceId);
+  const caps = cameraCapabilities(sourceId);
   cameraApplyPending.add(key);
   updateCameraApplyUi(key);
   try {
@@ -1685,8 +1692,8 @@ async function saveCameraSettings(sourceId: string): Promise<void> {
       sourceId,
       desired: {
         displayName: draft.displayName,
-        overlayText: draft.overlayText,
-        overlayTimestamp: draft.overlayTimestamp,
+        overlayText: caps.overlayText ? draft.overlayText : "",
+        overlayTimestamp: caps.overlayTimestamp ? draft.overlayTimestamp : false,
         desiredPassword: draft.desiredPassword,
         generatePassword: draft.generatePassword,
         hardening: {
@@ -2251,7 +2258,7 @@ function extractAnswerDescription(result: GatewaySignalResult): RTCSessionDescri
     direct;
 
   const type = String(candidate?.type || "").trim();
-  const sdp = String(candidate?.sdp || "").trim();
+  const sdp = typeof candidate?.sdp === "string" ? candidate.sdp : "";
   if (!type || !sdp) {
     throw new Error("gateway answer payload is missing type/sdp");
   }
@@ -2615,22 +2622,24 @@ function buildCameraSettingsTray(sourceId: string): HTMLElement {
   }
 
   const draft = cameraSettingsDraft(sourceId);
-  const vendor = String(mounted?.vendor || mounted?.observed?.vendor || "").trim() || "Reolink";
-  const model = String(mounted?.model || mounted?.observed?.model || "").trim() || "E1 Outdoor SE";
-  const driverId = String(mounted?.driverId || mounted?.observed?.driverId || "").trim() || "reolink";
+  const vendor = String(mounted?.vendor || mounted?.observed?.vendor || "").trim();
+  const model = String(mounted?.model || mounted?.observed?.model || "").trim();
+  const driverId = String(mounted?.driverId || mounted?.observed?.driverId || "").trim();
   const currentPose = currentPoseBySourceId.get(sourceId) || mounted?.currentPose || mounted?.observed?.currentPose || {};
   const poseStatus = String(poseStatusBySourceId.get(sourceId) || mounted?.poseStatus || mounted?.observed?.poseStatus || "idle").trim() || "idle";
   const adminWarning = viewerIsOwner() && !!cameraInventoryError;
+  const showPtzSummary = !!(PTZ_UI_ENABLED && (caps.ptz || camera.ptzCapable || mounted?.observed?.ptzCapable));
 
   const summaryPanel = document.createElement("section");
   summaryPanel.className = "nestedPanel";
   summaryPanel.innerHTML = `
     <div class="summaryLabel">Camera Summary</div>
-    ${renderKvRow("Driver", driverId)}
-    ${renderKvRow("Model", model)}
+    ${driverId ? renderKvRow("Driver", driverId) : ""}
+    ${vendor ? renderKvRow("Vendor", vendor) : ""}
+    ${model ? renderKvRow("Model", model) : ""}
     ${renderKvRow("Access", cameraAccessSummary(camera))}
-    ${PTZ_UI_ENABLED ? renderKvRow("PTZ", camera.ptzCapable ? (camera.controlGranted ? "owner control ready" : "available") : "not supported") : ""}
-    ${renderKvRow("Pose", formatPose(currentPose, poseStatus))}
+    ${showPtzSummary ? renderKvRow("PTZ", camera.controlGranted ? "owner control ready" : "available") : ""}
+    ${showPtzSummary ? renderKvRow("Pose", formatPose(currentPose, poseStatus)) : ""}
   `;
   tray.appendChild(summaryPanel);
 
@@ -2929,7 +2938,9 @@ async function connectLiveGrid(context: LaunchContext): Promise<void> {
     cancelScheduledReconnect();
     reconnectAttemptCount = 0;
     const sourceId = sourceIdForTrack(event);
-    const stream = event.streams[0] || new MediaStream([event.track]);
+    // Bind each preview tile to the specific remote video track instead of trusting
+    // browser stream grouping. Multiple remote video tracks may share one MediaStream id.
+    const stream = new MediaStream([event.track]);
     attachTrackToTile(sourceId || event.track.id, stream);
     setConnectionState("live", "good");
     setDrawerStatus("Live preview connected.");

--- a/tests/managed-launch.spec.ts
+++ b/tests/managed-launch.spec.ts
@@ -25,6 +25,9 @@ type LaunchContext = {
       viewGranted: boolean;
       controlGranted: boolean;
       ptzCapable: boolean;
+      driverId?: string;
+      vendor?: string;
+      model?: string;
     }>;
     grantedScope?: {
       owner?: boolean;
@@ -47,6 +50,8 @@ type RuntimeMockConfig = {
   ownerInventory?: boolean;
   adminDelayMs?: number;
   applyDelayMs?: number;
+  sharedTrackStream?: boolean;
+  staleMountedDisplayNameAfterApply?: boolean;
   cameraNetwork?: {
     managed?: boolean;
     interface?: string;
@@ -199,17 +204,29 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
       }
 
       async setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void> {
+        if (description?.type === "answer" && typeof description.sdp === "string" && !description.sdp.endsWith("\r\n")) {
+          throw new Error("answer SDP lost trailing CRLF");
+        }
         this.remoteDescription = description;
         this.iceConnectionState = "connected";
         this.connectionState = "connected";
         this.emit("iceconnectionstatechange");
         this.emit("connectionstatechange");
+        const sharedStream = runtimeConfig.sharedTrackStream ? new MediaStream() : null;
         for (const transceiver of this.transceivers) {
-          const stream = new MediaStream();
+          const stream = sharedStream || new MediaStream();
+          const canvas = document.createElement("canvas");
+          canvas.width = 16;
+          canvas.height = 16;
+          const ctx = canvas.getContext("2d");
+          ctx?.fillRect(0, 0, 16, 16);
+          const generated = canvas.captureStream(1).getVideoTracks()[0];
+          const track = generated.clone();
+          if (sharedStream) sharedStream.addTrack(track);
           this.emit("track", {
             transceiver,
             streams: [stream],
-            track: { id: `track-${transceiver.mid}` },
+            track,
           });
         }
       }
@@ -456,11 +473,16 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
                   ? adminPayload.desired as Record<string, unknown>
                   : {};
                 const camera = mutableCameras.get(sourceId);
+                let responseDisplayName = "";
+                let responseDesiredDisplayName = "";
                 if (camera) {
+                  const previousName = String(camera.name || "").trim() || sourceId;
                   const nextName = String(desired.displayName || camera.name || "").trim() || camera.name;
                   const nextOverlayText = String(desired.overlayText || camera.overlayText || nextName).trim() || nextName;
                   camera.name = nextName;
                   camera.overlayText = nextOverlayText;
+                  responseDisplayName = runtimeConfig.staleMountedDisplayNameAfterApply ? previousName : camera.name;
+                  responseDesiredDisplayName = runtimeConfig.staleMountedDisplayNameAfterApply ? previousName : camera.name;
                 }
                 this.emit(runtimeResponse(requestId, {
                   requestId: signalRequestId,
@@ -471,7 +493,10 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
                       mounted: camera
                         ? {
                             sourceId: camera.sourceId,
-                            displayName: camera.name,
+                            displayName: responseDisplayName,
+                            driverId: camera.driverId || "",
+                            vendor: camera.vendor || "",
+                            model: camera.model || "",
                             capabilities: {
                               liveView: true,
                               ptz: camera.ptzCapable,
@@ -481,12 +506,15 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
                               overlayTimestamp: true,
                             },
                             desired: {
-                              displayName: camera.name,
+                              displayName: responseDesiredDisplayName,
                               overlayText: camera.overlayText,
                               overlayTimestamp: true,
                             },
                             observed: {
                               displayName: camera.name,
+                              driverId: camera.driverId || "",
+                              vendor: camera.vendor || "",
+                              model: camera.model || "",
                               overlayText: camera.overlayText,
                               overlayTimestamp: true,
                               ptzCapable: camera.ptzCapable,
@@ -516,6 +544,9 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
                           mounted: cameras.map((camera) => ({
                             sourceId: camera.sourceId,
                             displayName: camera.name,
+                            driverId: camera.driverId || "",
+                            vendor: camera.vendor || "",
+                            model: camera.model || "",
                             capabilities: {
                               liveView: true,
                               ptz: camera.ptzCapable,
@@ -531,6 +562,9 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
                             },
                             observed: {
                               displayName: camera.name,
+                              driverId: camera.driverId || "",
+                              vendor: camera.vendor || "",
+                              model: camera.model || "",
                               overlayText: camera.overlayText,
                               overlayTimestamp: true,
                               ptzCapable: camera.ptzCapable,
@@ -709,6 +743,32 @@ test("reconnects live preview automatically after the peer connection drops", as
   await expect(page.locator(".cameraStatusDot-live")).toHaveCount(2);
 });
 
+test("binds each preview tile to its own track even when remote tracks share one MediaStream", async ({ page }) => {
+  await installRuntimeHarness(page, {
+    launchContext: buildLaunchContext(),
+    diagnostics: false,
+    expireOfferPreflight: false,
+    ownerInventory: false,
+    sharedTrackStream: true,
+  });
+  await page.goto("/#launch=launch-test-001");
+
+  await expect(page.locator(".cameraStatusDot-live")).toHaveCount(2);
+  const trackBinding = await page.evaluate(() => {
+    return Array.from(document.querySelectorAll(".cameraTile video")).map((video) => {
+      const stream = (video as HTMLVideoElement).srcObject as MediaStream | null;
+      return {
+        trackIds: stream ? stream.getVideoTracks().map((track) => track.id) : [],
+      };
+    });
+  });
+
+  expect(trackBinding).toHaveLength(2);
+  expect(trackBinding[0]?.trackIds).toHaveLength(1);
+  expect(trackBinding[1]?.trackIds).toHaveLength(1);
+  expect(trackBinding[0]?.trackIds[0]).not.toBe(trackBinding[1]?.trackIds[0]);
+});
+
 test("hides the close affordance when no shell opener is available", async ({ page }) => {
   await installRuntimeHarness(page);
   await page.goto("/#launch=launch-test-001");
@@ -850,6 +910,55 @@ test("camera settings use site time policy and do not expose per-camera time con
   await expect(summary).toContainText("192.168.250.1");
   await expect(summary).toContainText("Timezone");
   await expect(summary).toContainText("America/Phoenix");
+});
+
+test("xm camera settings show XM driver truth and no PTZ fallback rows", async ({ page }) => {
+  const context = buildLaunchContext({
+    display: {
+      serviceLabel: "Lab NVR",
+      serviceVersion: "0.2.0",
+      service: "nvr",
+      status: "ready",
+      cameraCount: 1,
+      configuredSources: 1,
+      sources: ["cam-xm"],
+      cameras: [
+        {
+          sourceId: "cam-xm",
+          name: "XM Camera",
+          viewGranted: true,
+          controlGranted: true,
+          ptzCapable: false,
+          driverId: "xm_40e",
+          vendor: "XM/NetSurveillance",
+          model: "40E",
+        },
+      ],
+      grantedScope: {
+        owner: true,
+        viewSources: ["cam-xm"],
+        controlSources: ["cam-xm"],
+      },
+      iceServers: {
+        stun: ["stun:stun.example.invalid:3478"],
+      },
+    },
+  });
+
+  await installRuntimeHarness(page, {
+    launchContext: context,
+    ownerInventory: true,
+  });
+
+  await page.goto("/#launch=launch-test-001&activity=settings&settings=cameras&camera=cam-xm");
+
+  const card = page.locator(".cameraListItem.expanded[data-source-id='cam-xm']");
+  await expect(card).toBeVisible();
+  await expect(card.locator(".nestedPanel")).toContainText("xm_40e");
+  await expect(card.locator(".nestedPanel")).toContainText("XM/NetSurveillance");
+  await expect(card.locator(".nestedPanel")).toContainText("40E");
+  await expect(card.locator(".nestedPanel")).not.toContainText("E1 Outdoor SE");
+  await expect(card.locator(".nestedPanel")).not.toContainText("Pose");
 });
 
 test("temporarily hides PTZ controls while PTZ is disabled", async ({ page }) => {
@@ -1170,4 +1279,55 @@ test("apply camera settings stays mounted while the request is pending", async (
   await expect(cameraCard).toBeVisible();
   await expect(nameInput).toHaveValue("Driveway");
   await expect(page.locator(".cameraListItem .cameraListHeading strong")).toHaveText("Driveway");
+});
+
+test("camera card title follows observed validated name when mounted displayName is stale", async ({ page }) => {
+  const context = buildLaunchContext({
+    display: {
+      serviceLabel: "Lab NVR",
+      serviceVersion: "0.2.0",
+      service: "nvr",
+      status: "ready",
+      cameraCount: 1,
+      configuredSources: 1,
+      sources: ["cam-front"],
+      cameras: [
+        {
+          sourceId: "cam-front",
+          name: "Front Door",
+          viewGranted: true,
+          controlGranted: true,
+          ptzCapable: true,
+        },
+      ],
+      grantedScope: {
+        owner: true,
+        viewSources: ["cam-front"],
+        controlSources: ["cam-front"],
+      },
+      iceServers: {
+        stun: ["stun:stun.example.invalid:3478"],
+      },
+    },
+  });
+
+  await installRuntimeHarness(page, {
+    launchContext: context,
+    diagnostics: false,
+    expireOfferPreflight: false,
+    ownerInventory: true,
+    staleMountedDisplayNameAfterApply: true,
+  });
+
+  await page.goto("/#launch=launch-test-001&activity=settings&settings=cameras&camera=cam-front");
+
+  const cameraCard = page.locator(".cameraListItem.expanded[data-source-id='cam-front']");
+  const nameInput = cameraCard.locator(".cameraSettingsTray input[data-field='displayName']");
+  const applyButton = cameraCard.locator("button[data-action='apply-camera-settings']");
+
+  await expect(cameraCard.locator(".cameraListHeading strong")).toHaveText("Front Door");
+  await nameInput.fill("Driveway");
+  await applyButton.click();
+
+  await expect(cameraCard.locator(".cameraListHeading strong")).toHaveText("Driveway");
 });


### PR DESCRIPTION
## Summary
- render XM 40E driver, vendor, and model truth in the managed camera settings surface
- hide false PTZ/Reolink assumptions and capability-gate overlay behavior
- keep camera titles, Firefox SDP handling, and multi-track preview binding aligned with validated runtime truth

## Validation
- 
pm run build
- 
px playwright test tests/managed-launch.spec.ts

Closes #7