### PR TITLE
refactor(nvr-ui): adopt shared shell and direct entry

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,25 +7,31 @@ It is a Pages-hosted managed app surface.
 It is not a transport/gateway replacement and does not host identity authority.
 
 ## Boundaries
-- Identity authority and wallet: `constitute` shell
-- Same-origin launch/runtime coordination: `constitute/runtime.worker.js`
+- Identity/session/grant authority: `constitute-account`
+- Same-origin launch/runtime coordination: `constitute-account/runtime.worker.js`
+- Shared first-party chrome/primitives: `constitute-ui`
 - Browser control/signaling boundary: `constitute-gateway`
 - Hosted media/service endpoint: `constitute-nvr`
 
 ## Managed Launch Flow
-1. `constitute` opens `tld/constitute-nvr-ui/` with a non-secret `launchId`.
-2. Shared runtime exposes short-lived launch context through same-origin worker state, with local storage / legacy app-channel fallback where needed.
+1. User opens `tld/constitute-nvr-ui/` directly or a first-party surface opens it with a non-secret `launchId`.
+2. Shared runtime exposes short-lived launch context through same-origin worker state.
 3. NVR UI redeems launch context and learns target gateway/service metadata.
 4. UI requests or receives gateway-mediated launch authorization.
 5. UI uses gateway-mediated signaling to establish WebRTC with the hosted NVR service.
 6. UI renders the live camera grid from WebRTC preview tracks.
 
+Direct entry is the primary flow. The user should not need to visit `constitute-account` manually first. If retained runtime projection is insufficient, NVR UI should keep resolving account/session/grant state through the shared runtime and present scoped account-required state instead of treating a single timed launch attempt as final product truth.
+
 ## UI Scope
-Current managed MVP:
+Current managed surface:
 - no-camera state
 - connecting state
 - live camera tiles
 - unavailable/error state
+- shared footer account-state rail with mini account center
+- diagnostics stay in console/debug side channels; the primary UI does not expose a session-log panel
+- the shared account rail opens account actions only; app-specific opener-return controls are not part of the current shared contract
 
 Advanced configuration remains out of scope for this slice except navigation placeholders.
 
@@ -33,6 +39,8 @@ Advanced configuration remains out of scope for this slice except navigation pla
 - WebRTC
 - H.264 preview
 - substream / low-resolution feed where available for multi-camera grid
+- WebRTC media is encrypted in transit through DTLS-SRTP
+- future NVR media projection should let this app attach to a warm browser-safe preview stream instead of always paying cold camera/ffmpeg startup cost
 
-## Legacy Debug Mode
-Standalone direct `/session` websocket attachment remains available for lab/debug, but it is not the canonical production launch path.
+## Debug Surface
+Manual protocol helpers may exist for lab verification, but the browser app's canonical launch path is direct app entry through `constitute-account` shared runtime and gateway-mediated signaling.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm run test:e2e
 - App manifest: `app.manifest.json`
 - Default manifest entry: `dist/index.html`
 - Build output is committed for static hosting under the site domain.
-- Local static monorepo hosting should serve the app at `/constitute-nvr-ui/`; the local project-root server maps that route to this repo's built `dist/` output without exposing `/dist/` in the canonical URL.
+- Static hosting should serve the app at `/constitute-nvr-ui/` without exposing `/dist/` in the canonical URL.
 
 ## Managed Launch Bootstrap
 Canonical launch direction:

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 `constitute-nvr-ui` is the browser app module for `constitute-nvr`.
 
-Current scope is managed-app MVP support:
+Current scope is the first-party Security Cameras surface:
 - load as a Pages-hosted app surface at `tld/constitute-nvr-ui/`
-- redeem short-lived launch context from shared runtime / `constitute`
+- redeem short-lived launch context from the shared runtime in `constitute-account`
 - establish gateway-mediated signaling/auth for `constitute-nvr`
-- render a simple live camera grid over WebRTC H.264 preview tracks
+- render live camera tiles over WebRTC H.264 preview tracks
 
 ## Security Position
 - UI does not receive executable code from NVR transport.
-- Identity/wallet ownership remains in `constitute` shell.
+- Identity/session/grant authority remains in `constitute-account`.
 - Managed launch must not require long-lived identity secrets in URL parameters.
-- Direct/manual debug mode may still use explicit operator-supplied secrets outside the canonical flow.
+- Manual protocol/debug helpers are not part of the canonical browser launch path.
 
 ## Run
 ```bash
@@ -26,18 +26,17 @@ npm run test:e2e
 - App manifest: `app.manifest.json`
 - Default manifest entry: `dist/index.html`
 - Build output is committed for static hosting under the site domain.
-- Local static monorepo hosting should serve the built surface at `/constitute-nvr-ui/dist/`.
+- Local static monorepo hosting should serve the app at `/constitute-nvr-ui/`; the local project-root server maps that route to this repo's built `dist/` output without exposing `/dist/` in the canonical URL.
 
 ## Managed Launch Bootstrap
 Canonical launch direction:
-- shell opens this app with a short-lived `launchId`
-- shared runtime exposes matching launch context, with local storage / legacy app-channel fallback where needed
+- direct app entry or another first-party surface opens this app with a short-lived `launchId`
+- shared runtime exposes matching launch context
 - app redeems that context and then negotiates signaling/auth through the owned gateway
+
+Shared first-party chrome comes from `constitute-ui`, including the footer account rail and mini account center entrypoint.
 
 Long-lived identity secrets should not be passed in query parameters.
 
-## Legacy Debug Mode
-Manual direct `/session` attachment remains available for lab work while the managed path is under active implementation.
-
 ## Status
-MVP/manual-test ready. Not production-ready.
+Ready for managed browser-surface convergence testing against the shared runtime and gateway-mediated launch path.

--- a/index.src.html
+++ b/index.src.html
@@ -54,22 +54,6 @@
         to { transform: translateY(-2px) scale(1.015); text-shadow: 0 10px 28px rgba(87, 209, 191, 0.18); }
       }
     </style>
-    <script>
-      (() => {
-        const host = String(window.location.hostname || "").toLowerCase();
-        const path = String(window.location.pathname || "");
-        const isLocal = host === "localhost" || host === "127.0.0.1";
-        const atRepoRoot = /\/constitute-nvr-ui\/?$/.test(path);
-        if (isLocal && atRepoRoot) {
-          const target = new URL("./dist/", window.location.href);
-          target.search = window.location.search;
-          target.hash = window.location.hash;
-          window.location.replace(target.toString());
-          return;
-        }
-        window.__CONSTITUTE_NVR_UI_DEV_ENTRY__ = "/src/main.ts";
-      })();
-    </script>
   </head>
   <body class="booting">
     <div id="bootSplash" aria-live="polite" role="status">
@@ -79,15 +63,6 @@
       </div>
     </div>
     <div id="app"></div>
-    <script>
-      (() => {
-        const entry = String(window.__CONSTITUTE_NVR_UI_DEV_ENTRY__ || "").trim();
-        if (!entry) return;
-        const script = document.createElement("script");
-        script.type = "module";
-        script.src = entry;
-        document.body.appendChild(script);
-      })();
-    </script>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,19 @@
       "dependencies": {
         "@noble/ciphers": "^1.2.1",
         "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0"
+        "@noble/hashes": "^1.8.0",
+        "constitute-ui": "file:../constitute-ui"
       },
       "devDependencies": {
         "@playwright/test": "^1.54.2",
         "typescript": "^5.9.2",
         "vite": "^6.2.0"
+      }
+    },
+    "../constitute-ui": {
+      "version": "0.1.0",
+      "devDependencies": {
+        "jsdom": "^27.0.1"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -871,6 +878,10 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/constitute-ui": {
+      "resolved": "../constitute-ui",
+      "link": true
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@noble/ciphers": "^1.2.1",
     "@noble/curves": "^1.9.7",
-    "@noble/hashes": "^1.8.0"
+    "@noble/hashes": "^1.8.0",
+    "constitute-ui": "file:../constitute-ui"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     headless: true,
   },
   webServer: {
-    command: "npm run dev -- --host 127.0.0.1 --port 4173",
+    command: "npx vite --force --host 127.0.0.1 --port 4173",
     port: 4173,
     timeout: 120_000,
     reuseExistingServer: !process.env.CI,

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -36,7 +36,7 @@ if (!entry?.file) {
   throw new Error("Could not resolve built NVR UI entry from Vite manifest.");
 }
 
-const sourceHtml = await readFile(resolve(workspaceRoot, "index.html"), "utf8");
+const sourceHtml = await readFile(resolve(workspaceRoot, "index.src.html"), "utf8");
 const cssLinks = Array.isArray(entry.css)
   ? entry.css.map((file) => `    <link rel="stylesheet" href="./${file}" />`).join("\n")
   : "";

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,6 @@
+import "constitute-ui/styles.css";
 import "./styles.css";
+import { renderActionList, renderAccountCenterSummary, setConnectionStateText } from "constitute-ui";
 import { renderShell } from "./shell";
 
 type IceServerHints = {
@@ -298,6 +300,10 @@ type RuntimeSnapshot = {
   launchContextCount?: number;
 };
 
+type ManagedApplianceRecord = Record<string, unknown> & {
+  __scope?: string;
+};
+
 type CameraSettingsDraft = {
   displayName: string;
   overlayText: string;
@@ -326,15 +332,21 @@ const SIGNAL_REQUEST_TIMEOUT_MS = 30_000;
 const ADMIN_SIGNAL_REQUEST_TIMEOUT_MS = 135_000;
 const CAMERA_APPLY_REQUEST_TIMEOUT_MS = 135_000;
 const GRANT_REQUEST_TIMEOUT_MS = 30_000;
-const RUNTIME_WORKER_VERSION = Object.freeze({ major: 2, minor: 8 });
+const DIRECT_ENTRY_LAUNCH_REQUEST_TIMEOUT_MS = 135_000;
+const DIRECT_ENTRY_LAUNCH_RETRY_BASE_MS = 1_000;
+const DIRECT_ENTRY_LAUNCH_RETRY_MAX_MS = 10_000;
+const RUNTIME_WORKER_VERSION = Object.freeze({ major: 2, minor: 9 });
 const RUNTIME_WORKER_BUILD_ID = `runtime-${RUNTIME_WORKER_VERSION.major}.${RUNTIME_WORKER_VERSION.minor}`;
 const RUNTIME_ATTACH_TIMEOUT_MS = 5_000;
 const RUNTIME_WRITE_TIMEOUT_MS = 10_000;
+const DIRECT_ENTRY_ACCOUNT_HYDRATION_TIMEOUT_MS = 15_000;
+const DIRECT_ENTRY_ACCOUNT_HYDRATION_POLL_MS = 350;
+const DIRECT_ENTRY_ACCOUNT_HYDRATED_SETTLE_MS = 2_000;
 const LAUNCH_REFRESH_SKEW_MS = 15_000;
 const PTZ_STEP_DEGREES = 10;
 const PTZ_STEP_NORMALIZED = PTZ_STEP_DEGREES / 180;
-// Temporary kill-switch: hide PTZ UI until the Reolink path stops failing with
-// native absolute `405`/no-move plus CGI session exhaustion (`rspCode -5: max session`).
+// Keep PTZ hidden until the driver reports a verified control surface.
+// The current Reolink control path is not reliable enough to expose generically.
 const PTZ_UI_ENABLED = false;
 
 const app = document.querySelector<HTMLDivElement>("#app");
@@ -347,12 +359,15 @@ const btnBellEl = shell.btnBellEl;
 const notifMenuEl = shell.notifMenuEl;
 const btnNotifClearEl = shell.btnNotifClearEl;
 const notifListEl = shell.notifListEl;
-const closeAppButtonEl = shell.closeAppButtonEl;
 const btnMenuEl = shell.btnMenuEl;
 const drawerEl = shell.drawerEl;
 const drawerBackdropEl = shell.drawerBackdropEl;
 const btnDrawerCloseEl = shell.btnDrawerCloseEl;
 const navButtons = shell.navButtons;
+const accountRailButtonEl = shell.accountRailButtonEl;
+const accountCenterMenuEl = shell.accountCenterMenuEl;
+const accountCenterSummaryEl = shell.accountCenterSummaryEl;
+const accountCenterActionsEl = shell.accountCenterActionsEl;
 const identityHandleEl = shell.identityHandleEl;
 const connWrapEl = shell.connWrapEl;
 const connStateTextEl = shell.connStateTextEl;
@@ -375,8 +390,6 @@ const camerasPanelEl = shell.camerasPanelEl;
 const cameraListEl = shell.cameraListEl;
 const addCameraButtonEl = shell.addCameraButtonEl;
 const cameraRefreshStatusEl = shell.cameraRefreshStatusEl;
-const logPanelEl = shell.logPanelEl;
-const logEl = shell.logEl;
 const nvrSettingsSummaryEl = document.getElementById("nvrSettingsSummary") as HTMLDivElement | null;
 
 const cameraTiles = new Map<string, CameraTile>();
@@ -391,7 +404,6 @@ let resolveRuntimeReady: ((value: MessagePort | null) => void) | null = null;
 let launchContext: LaunchContext | null = null;
 let peerConnection: RTCPeerConnection | null = null;
 let transceiverSourceIds: string[] = [];
-const logLines: string[] = [];
 let diagnosticsEnabled = false;
 let bootSplashDismissed = false;
 let grantInventory: GrantInventory | null = null;
@@ -417,11 +429,14 @@ let cameraInventoryError = "";
 let cameraInventoryRefreshPromise: Promise<void> | null = null;
 let expandedCandidateId = "";
 let notificationMenuOpen = false;
-let identityHandleCopied = false;
+let accountCenterOpen = false;
 let launchRefreshPromise: Promise<LaunchContext> | null = null;
 let scheduledReconnectTimer = 0;
 let reconnectInFlight: Promise<void> | null = null;
 let reconnectAttemptCount = 0;
+let accountBridgeFrame: HTMLIFrameElement | null = null;
+let accountBridgePromise: Promise<void> | null = null;
+let directEntryLaunchAttempted = false;
 
 function ptzUiCapable(camera: LaunchCameraDisplay | null | undefined): boolean {
   return PTZ_UI_ENABLED && camera?.ptzCapable === true;
@@ -453,10 +468,7 @@ function asManagedLaunchError(error: unknown, fallbackStage: LaunchStage): Manag
 }
 
 function appendLog(message: string): void {
-  const line = `[${new Date().toLocaleTimeString()}] ${message}`;
-  logLines.push(line);
   if (diagnosticsEnabled) {
-    renderLogBuffer();
     console.info(`[nvr-ui] ${message}`);
   }
 }
@@ -540,11 +552,13 @@ function connectionTextClass(tone: "neutral" | "warn" | "good" | "bad"): string 
 }
 
 function setConnectionState(label: string, tone: "neutral" | "warn" | "good" | "bad"): void {
-  connStateTextEl.textContent = label;
-  connStateTextEl.classList.remove("connStateText-connected", "connStateText-limited", "connStateText-error");
-  connStateTextEl.classList.add(connectionTextClass(tone));
+  setConnectionStateText(connStateTextEl, {
+    label,
+    toneClass: connectionTextClass(tone),
+  });
   popConnectionEl.textContent = label.toLowerCase();
   popRelayEl.textContent = label.toLowerCase();
+  renderAccountCenter();
 }
 
 function setDrawerStatus(detail: string): void {
@@ -562,12 +576,6 @@ function rememberResolvedResourceName(pk: unknown, label: unknown): void {
   const text = String(label || "").trim();
   if (!key || !text) return;
   resolvedResourceNames.set(key, text);
-}
-
-function resetIdentityHandleCopyHint(): void {
-  if (!identityHandleCopied) return;
-  identityHandleCopied = false;
-  refreshIdentityHandle();
 }
 
 function absorbRuntimeSnapshot(snapshot: unknown): void {
@@ -717,17 +725,8 @@ function persistDiagnosticsPreference(enabled: boolean): void {
   } catch {}
 }
 
-function renderLogBuffer(): void {
-  logEl.textContent = logLines.join("\n");
-  logEl.scrollTop = logEl.scrollHeight;
-}
-
 function applyDiagnosticsMode(): void {
   diagnosticsEnabled = readDiagnosticsPreference();
-  logPanelEl.classList.toggle("diagnostics-hidden", !diagnosticsEnabled);
-  if (diagnosticsEnabled) {
-    renderLogBuffer();
-  }
 }
 
 function installDiagnosticsBridge(): void {
@@ -757,7 +756,7 @@ function installDiagnosticsBridge(): void {
 }
 
 function shellBaseUrl(): string {
-  return new URL("/constitute/", window.location.origin).toString();
+  return new URL("/constitute-account/", window.location.origin).toString();
 }
 
 function setBootSplash(title: string): void {
@@ -775,18 +774,6 @@ function dismissBootSplash(): void {
       bootSplashEl.remove();
     } catch {}
   }, 220);
-}
-
-function hasShellOpener(): boolean {
-  try {
-    return Boolean(window.opener && !window.opener.closed);
-  } catch {
-    return false;
-  }
-}
-
-function updateCloseAppButton(): void {
-  closeAppButtonEl.hidden = !hasShellOpener();
 }
 
 function openNotificationMenu(): void {
@@ -812,8 +799,16 @@ function toggleNotificationMenu(): void {
 function identityHandleForContext(context: LaunchContext | null): string {
   const identityId = String(context?.identityId || "").trim();
   if (!identityId) return "@unlinked";
-  const label = resolvedResourceName(identityId, shortPk(identityId));
-  return `@${String(label || "identity").replace(/^@+/, "")}`;
+  const runtimeHandle = runtimeIdentityHandle();
+  if (runtimeHandle !== "@linked") return runtimeHandle;
+  const label = String(resolvedResourceNames.get(identityId) || "").trim().replace(/^@+/, "");
+  return label ? `@${label}` : runtimeHandle;
+}
+
+function runtimeIdentityHandle(): string {
+  const rawLabel = String(runtimeSnapshot?.shell?.identity?.label || "").trim().replace(/^@+/, "");
+  if (rawLabel) return `@${rawLabel}`;
+  return "@linked";
 }
 
 function refreshIdentityHandle(): void {
@@ -822,30 +817,72 @@ function refreshIdentityHandle(): void {
   identityHandleEl.textContent = identityHandleForContext(launchContext);
   identityHandleEl.classList.toggle("identityHandle-linked", linked);
   identityHandleEl.classList.toggle("identityHandle-unlinked", !linked);
-  identityHandleEl.title = identityId
-    ? (identityHandleCopied ? "Copied!" : "Click to copy ID")
-    : "Identity not linked yet";
+  identityHandleEl.title = linked ? "Open account center" : "Open account center";
   identityHandleEl.setAttribute("aria-label", identityId ? `Identity ${identityId}` : "Identity not linked");
+  renderAccountCenter();
 }
 
-async function focusShellAndClose(): Promise<void> {
-  let openerFocused = false;
-  try {
-    if (window.opener && !window.opener.closed) {
-      window.opener.focus();
-      openerFocused = true;
-    }
-  } catch {}
+function openAccountCenter(): void {
+  accountCenterOpen = true;
+  accountCenterMenuEl.classList.remove("hidden");
+  accountRailButtonEl.setAttribute("aria-expanded", "true");
+}
 
-  try {
-    window.close();
-  } catch {}
+function closeAccountCenter(): void {
+  accountCenterOpen = false;
+  accountCenterMenuEl.classList.add("hidden");
+  accountRailButtonEl.setAttribute("aria-expanded", "false");
+}
 
-  window.setTimeout(() => {
-    if (window.closed) return;
-    if (openerFocused) return;
-    closeAppButtonEl.hidden = true;
-  }, 150);
+function toggleAccountCenter(): void {
+  if (accountCenterOpen) {
+    closeAccountCenter();
+  } else {
+    openAccountCenter();
+  }
+}
+
+function openAccountCenterApp(targetHash = ""): void {
+  const url = new URL("/constitute-account/", window.location.origin);
+  if (targetHash) url.hash = targetHash;
+  window.location.assign(url.toString());
+}
+
+function renderAccountCenter(): void {
+  const identityId = String(launchContext?.identityId || "").trim();
+  const handle = identityHandleForContext(launchContext);
+  const connection = String(connStateTextEl.textContent || "Offline").trim() || "Offline";
+  renderAccountCenterSummary(accountCenterSummaryEl, {
+    handle,
+    linked: Boolean(identityId),
+    connectionLabel: connection,
+    connectionToneClass: Array.from(connStateTextEl.classList)
+      .find((value) => value.startsWith("connStateText-") && value !== "connStateText")
+      || "connStateText-offline",
+  });
+  renderActionList(accountCenterActionsEl, [
+    {
+      id: "account.open_center",
+      label: "Open Account Center",
+      description: "Open constitute-account.",
+      onSelect: () => openAccountCenterApp("activity=home"),
+    },
+    {
+      id: "account.copy_identity",
+      label: "Copy Identity ID",
+      description: identityId ? "Copy the linked identity id." : "Identity is not linked yet.",
+      disabled: !identityId,
+      onSelect: async () => {
+        if (!identityId) return;
+        try {
+          await navigator.clipboard.writeText(identityId);
+          addNotification("good", "Identity copied", "Copied the linked identity id.", "account");
+        } catch (error) {
+          addNotification("bad", "Identity copy failed", String((error as Error)?.message || error), "account");
+        }
+      },
+    },
+  ]);
 }
 
 function openDrawer(): void {
@@ -907,9 +944,58 @@ function closeCameraSettings(): void {
 }
 
 function runtimeWorkerUrl(): string {
-  const target = new URL("/constitute/runtime.worker.js", window.location.origin);
+  const target = new URL("/constitute-account/runtime.worker.js", window.location.origin);
   target.searchParams.set("v", RUNTIME_WORKER_BUILD_ID);
   return target.toString();
+}
+
+function accountBridgeUrl(): string {
+  const target = new URL("/constitute-account/", window.location.origin);
+  target.searchParams.set("bridge", "1");
+  return target.toString();
+}
+
+function isRuntimeBrokerUnavailable(error: unknown): boolean {
+  const message = String((error as Error)?.message || error || "").toLowerCase();
+  return message.includes("runtime broker unavailable") || message.includes("runtime broker missing");
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, Math.max(0, ms)));
+}
+
+async function ensureAccountBridge(reason = ""): Promise<void> {
+  if (accountBridgePromise) return await accountBridgePromise;
+  accountBridgePromise = new Promise<void>((resolve) => {
+    let settled = false;
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    accountBridgeFrame = document.getElementById("constituteAccountBridge") as HTMLIFrameElement | null;
+    if (!accountBridgeFrame) {
+      const iframe = document.createElement("iframe");
+      iframe.id = "constituteAccountBridge";
+      iframe.hidden = true;
+      iframe.tabIndex = -1;
+      iframe.setAttribute("aria-hidden", "true");
+      iframe.style.cssText = "position:absolute;width:0;height:0;border:0;opacity:0;pointer-events:none";
+      iframe.src = accountBridgeUrl();
+      iframe.addEventListener("load", () => window.setTimeout(done, 450), { once: true });
+      document.body.appendChild(iframe);
+      accountBridgeFrame = iframe;
+    } else {
+      window.setTimeout(done, 450);
+    }
+    window.setTimeout(done, 1_500);
+    if (reason) appendLog(`opened account bridge (${reason})`);
+  });
+  try {
+    await accountBridgePromise;
+  } finally {
+    accountBridgePromise = null;
+  }
 }
 
 function handleRuntimeMessage(message: unknown): void {
@@ -1007,6 +1093,22 @@ async function runtimeCall<T = unknown>(type: string, payload: Record<string, un
   return await promise;
 }
 
+async function runtimeBrokerCall<T = unknown>(
+  type: string,
+  payload: Record<string, unknown>,
+  timeoutMs: number,
+  reason = "",
+): Promise<T> {
+  try {
+    return await runtimeCall<T>(type, payload, timeoutMs);
+  } catch (error) {
+    if (!isRuntimeBrokerUnavailable(error)) throw error;
+    appendLog(`runtime broker unavailable${reason ? ` during ${reason}` : ""}; booting account bridge`);
+    await ensureAccountBridge(reason || type);
+    return await runtimeCall<T>(type, payload, timeoutMs);
+  }
+}
+
 async function reportServiceStatus(state: string, reason: string, stage: LaunchStage | "" = ""): Promise<void> {
   try {
     await runtimeCall("runtime.status.put", {
@@ -1025,6 +1127,146 @@ async function reportServiceStatus(state: string, reason: string, stage: LaunchS
 
 async function requestLaunchContextFromRuntime(launchId: string): Promise<LaunchContext | null> {
   return await runtimeCall<LaunchContext | null>("launchContext.get", { launchId }, LAUNCH_REQUEST_TIMEOUT_MS);
+}
+
+function accountRuntimeNeedsIdentity(snapshot: RuntimeSnapshot | null): boolean {
+  const shell = snapshot?.shell && typeof snapshot.shell === "object"
+    ? snapshot.shell as Record<string, unknown>
+    : null;
+  const identity = shell?.identity && typeof shell.identity === "object"
+    ? shell.identity as Record<string, unknown>
+    : null;
+  return identity?.linked === false;
+}
+
+function accountRuntimeIdentityResolved(snapshot: RuntimeSnapshot | null): boolean {
+  const shell = snapshot?.shell && typeof snapshot.shell === "object"
+    ? snapshot.shell as Record<string, unknown>
+    : null;
+  const identity = shell?.identity && typeof shell.identity === "object"
+    ? shell.identity as Record<string, unknown>
+    : null;
+  return typeof identity?.linked === "boolean";
+}
+
+async function waitForDirectEntryNvrLaunchRecord(): Promise<{
+  snapshot: RuntimeSnapshot | null;
+  record: ManagedApplianceRecord | null;
+}> {
+  await ensureAccountBridge("direct app entry");
+  let snapshot = await currentRuntimeSnapshot();
+  let record = directEntryNvrLaunchRecord(snapshot);
+  if (record) return { snapshot, record };
+
+  const deadline = Date.now() + DIRECT_ENTRY_ACCOUNT_HYDRATION_TIMEOUT_MS;
+  let identityResolvedAt = 0;
+  while (Date.now() < deadline) {
+    snapshot = await currentRuntimeSnapshot();
+    record = directEntryNvrLaunchRecord(snapshot);
+    if (record) return { snapshot, record };
+    if (accountRuntimeIdentityResolved(snapshot)) {
+      identityResolvedAt ||= Date.now();
+      if (Date.now() - identityResolvedAt >= DIRECT_ENTRY_ACCOUNT_HYDRATED_SETTLE_MS) {
+        return { snapshot, record: null };
+      }
+    }
+    await delay(DIRECT_ENTRY_ACCOUNT_HYDRATION_POLL_MS);
+  }
+
+  return { snapshot, record: null };
+}
+
+async function requestDirectEntryLaunchContext(): Promise<LaunchContext> {
+  directEntryLaunchAttempted = true;
+  setConnectionState("launching", "warn");
+  setDrawerStatus("Launching Security Cameras through your account runtime.");
+  setGridEmpty("Launching Security Cameras", "Resolving an account-authorized camera session through the gateway.");
+  dismissBootSplash();
+  void reportServiceStatus("launching", "Resolving an account-authorized camera session.", "launch_authorization");
+
+  const { snapshot, record } = await waitForDirectEntryNvrLaunchRecord();
+  if (!record) {
+    if (accountRuntimeNeedsIdentity(snapshot)) {
+      throw launchError(
+        "launch_context",
+        "link an identity before opening Security Cameras",
+      );
+    }
+    throw launchError(
+      "launch_context",
+      "no Security Cameras service is available from this account runtime",
+    );
+  }
+
+  let selectedRecord = record;
+  let selectedSnapshot = snapshot;
+  let result: Record<string, unknown> | null = null;
+  let attempt = 0;
+  while (!result) {
+    attempt += 1;
+    try {
+      result = await runtimeBrokerCall<Record<string, unknown>>("gateway.launch.request", {
+        payload: {
+          record: selectedRecord,
+          options: {
+            service: "nvr",
+            capability: "nvr.view",
+          },
+        },
+      }, DIRECT_ENTRY_LAUNCH_REQUEST_TIMEOUT_MS, "direct app launch");
+    } catch (error) {
+      const message = String((error as Error)?.message || error || "Security Cameras launch failed");
+      const lowerMessage = message.toLowerCase();
+      if (lowerMessage.includes("link an identity") || lowerMessage.includes("identity is not linked")) {
+        throw launchError("launch_context", "link an identity before opening Security Cameras");
+      }
+      appendLog(`direct launch attempt ${attempt} deferred: ${message}`);
+      setConnectionState("launching", "warn");
+      setDrawerStatus("Security Cameras launch is still resolving through the gateway.");
+      setGridEmpty("Launching Security Cameras", "Resolving an account-authorized camera session through the gateway.");
+      void reportServiceStatus("launching", message, "launch_authorization");
+
+      const refreshedSnapshot = await currentRuntimeSnapshot().catch(() => null);
+      const refreshedRecord = directEntryNvrLaunchRecord(refreshedSnapshot);
+      if (refreshedRecord) {
+        selectedRecord = refreshedRecord;
+        selectedSnapshot = refreshedSnapshot;
+      }
+      const retryDelayMs = Math.min(
+        DIRECT_ENTRY_LAUNCH_RETRY_MAX_MS,
+        DIRECT_ENTRY_LAUNCH_RETRY_BASE_MS * Math.max(1, attempt),
+      );
+      await delay(retryDelayMs);
+    }
+  }
+  const launch = normalizeGatewayLaunchResult(result);
+  if (!launch.launchToken) {
+    throw launchError("launch_authorization", "Security Cameras launch returned no launch token");
+  }
+
+  const servicePk = String(launch.servicePk || applianceDevicePk(record)).trim();
+  const gatewayPk = String(launch.gatewayPk || applianceGatewayPk(record)).trim();
+  if (!servicePk || !gatewayPk) {
+    throw launchError("launch_authorization", "Security Cameras launch did not include service and gateway identity");
+  }
+
+  const identity = selectedSnapshot?.shell && typeof selectedSnapshot.shell === "object"
+    ? selectedSnapshot.shell.identity as Record<string, unknown> | undefined
+    : undefined;
+  return {
+    launchId: randomOpaqueId("launch"),
+    app: "nvr",
+    repo: "constitute-nvr-ui",
+    identityId: String(identity?.identityId || "").trim(),
+    devicePk: servicePk,
+    gatewayPk,
+    servicePk,
+    service: launch.service || "nvr",
+    launchToken: launch.launchToken,
+    display: launch.display ?? {},
+    createdAt: Date.now(),
+    expiresAt: Number(launch.expiresAt || (Date.now() + (2 * 60_000))),
+  };
 }
 
 function normalizeGatewayLaunchResult(result: unknown, fallbackRequestId = ""): GatewayLaunchResult {
@@ -1084,12 +1326,12 @@ function isExpiredLaunchTokenError(error: unknown): boolean {
 
 async function requestGatewayLaunch(): Promise<GatewayLaunchResult> {
   if (!launchContext) throw new Error("launch context is not loaded");
-  const result = await runtimeCall<Record<string, unknown>>("gateway.launch.request", {
+  const result = await runtimeBrokerCall<Record<string, unknown>>("gateway.launch.request", {
     payload: {
       record: launchRefreshRecord(launchContext),
       options: launchRefreshOptions(launchContext),
     },
-  }, LAUNCH_REFRESH_TIMEOUT_MS);
+  }, LAUNCH_REFRESH_TIMEOUT_MS, "launch refresh");
   appendLog("runtime broker delivered launch refresh");
   return normalizeGatewayLaunchResult(result);
 }
@@ -1139,7 +1381,7 @@ async function requestGatewaySignalOnce(
 ): Promise<GatewaySignalResult> {
   if (!launchContext) throw new Error("launch context is not loaded");
   const requestId = randomOpaqueId("nvr-signal");
-  const runtimeResult = await runtimeCall<GatewaySignalResult>("gateway.signal.request", {
+  const runtimeResult = await runtimeBrokerCall<GatewaySignalResult>("gateway.signal.request", {
     payload: {
       requestId,
       gatewayPk: launchContext.gatewayPk,
@@ -1149,7 +1391,7 @@ async function requestGatewaySignalOnce(
       signalType,
       payload,
     },
-  }, timeoutMs);
+  }, timeoutMs, signalType);
   appendLog(`runtime broker delivered ${signalType} response`);
   return runtimeResult;
 }
@@ -1179,7 +1421,7 @@ async function requestGatewayGrantAction(
 ): Promise<GatewayGrantResult> {
   if (!launchContext) throw new Error("launch context is not loaded");
   const requestId = randomOpaqueId("nvr-grant");
-  return await runtimeCall<GatewayGrantResult>("gateway.grant.request", {
+  return await runtimeBrokerCall<GatewayGrantResult>("gateway.grant.request", {
     payload: {
       requestId,
       gatewayPk: launchContext.gatewayPk,
@@ -1188,7 +1430,7 @@ async function requestGatewayGrantAction(
       action,
       ...payload,
     },
-  }, GRANT_REQUEST_TIMEOUT_MS);
+  }, GRANT_REQUEST_TIMEOUT_MS, action);
 }
 
 function unwrapGatewaySignalPayload(result: GatewaySignalResult): Record<string, unknown> {
@@ -1227,6 +1469,110 @@ function normalizeSourceIds(value: unknown): string[] {
     if (next && !out.includes(next)) out.push(next);
   }
   return out;
+}
+
+function normalizeRecords(value: unknown): ManagedApplianceRecord[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is ManagedApplianceRecord => Boolean(entry) && typeof entry === "object")
+    : [];
+}
+
+function normalizeRole(value: unknown): string {
+  return String(value || "").trim().toLowerCase();
+}
+
+function snapshotManagedApplianceRecords(snapshot: RuntimeSnapshot | null): ManagedApplianceRecord[] {
+  const managed = snapshot?.managedAppliances || {};
+  const buckets = [
+    { scope: "owned", items: normalizeRecords(managed.owned) },
+    { scope: "shared", items: normalizeRecords(managed.granted) },
+    { scope: "discoverable", items: normalizeRecords(managed.discoverable) },
+  ];
+  const out: ManagedApplianceRecord[] = [];
+  const seen = new Set<string>();
+  for (const bucket of buckets) {
+    for (const raw of bucket.items) {
+      const key = `${bucket.scope}:${String(raw.devicePk || raw.pk || raw.hostGatewayPk || raw.service || "").trim()}`;
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      out.push({ ...raw, __scope: bucket.scope });
+    }
+  }
+  return out;
+}
+
+function isGatewayApplianceRecord(record: ManagedApplianceRecord): boolean {
+  const role = normalizeRole(record.role || record.type || "");
+  const service = normalizeRole(record.service || "");
+  return role === "gateway" || service === "gateway";
+}
+
+function isNvrApplianceRecord(record: ManagedApplianceRecord): boolean {
+  if (isGatewayApplianceRecord(record)) return false;
+  const role = normalizeRole(record.role || record.type || "");
+  const service = normalizeRole(record.service || "");
+  return role === "nvr" || service === "nvr";
+}
+
+function applianceDevicePk(record: ManagedApplianceRecord): string {
+  return String(record.devicePk || record.device_pk || record.pk || "").trim();
+}
+
+function applianceGatewayPk(record: ManagedApplianceRecord): string {
+  return String(record.hostGatewayPk || record.host_gateway_pk || "").trim();
+}
+
+function applianceUpdatedAt(record: ManagedApplianceRecord): number {
+  return Number(
+    record.managedAvailabilityUpdatedAt
+      || record.managed_availability_updated_at
+      || record.updatedAt
+      || record.updated_at
+      || record.ts
+      || 0,
+  );
+}
+
+function directEntryNvrRecordFromGateway(gateway: ManagedApplianceRecord): ManagedApplianceRecord | null {
+  const gatewayPk = applianceDevicePk(gateway);
+  if (!gatewayPk) return null;
+  const hosted = normalizeRecords(gateway.hostedServices || gateway.hosted_services)
+    .find((service) => normalizeRole(service.service || service.slug || service.name || service) === "nvr");
+  if (!hosted) return null;
+  const servicePk = applianceDevicePk(hosted);
+  if (!servicePk) return null;
+  return {
+    ...hosted,
+    devicePk: servicePk,
+    pk: servicePk,
+    deviceKind: String(hosted.deviceKind || hosted.device_kind || "service"),
+    role: "nvr",
+    service: "nvr",
+    hostGatewayPk: gatewayPk,
+    serviceVersion: String(hosted.serviceVersion || hosted.service_version || ""),
+    updatedAt: Number(hosted.updatedAt || hosted.updated_at || gateway.updatedAt || gateway.updated_at || Date.now()),
+  };
+}
+
+function directEntryNvrLaunchRecord(snapshot: RuntimeSnapshot | null): ManagedApplianceRecord | null {
+  const records = snapshotManagedApplianceRecords(snapshot);
+  const services = records
+    .filter((record) => isNvrApplianceRecord(record) && applianceDevicePk(record) && applianceGatewayPk(record))
+    .sort((left, right) => applianceUpdatedAt(right) - applianceUpdatedAt(left));
+  if (services[0]) return services[0];
+  for (const gateway of records.filter(isGatewayApplianceRecord)) {
+    const hosted = directEntryNvrRecordFromGateway(gateway);
+    if (hosted) return hosted;
+  }
+  return null;
+}
+
+async function currentRuntimeSnapshot(): Promise<RuntimeSnapshot | null> {
+  try {
+    const snapshot = await runtimeCall<RuntimeSnapshot>("runtime.snapshot.get", {}, RUNTIME_WRITE_TIMEOUT_MS);
+    absorbRuntimeSnapshot(snapshot);
+  } catch {}
+  return runtimeSnapshot;
 }
 
 function buildRtcIceServers(hints: IceServerHints | undefined): RTCIceServer[] {
@@ -2352,6 +2698,43 @@ function formatPose(pose: CameraPoseView | null | undefined, status = ""): strin
   return `pan ${pan} • tilt ${tilt}${suffix}`;
 }
 
+function renderCameraNetworkSummary(network: CameraNetworkSummaryRecord): string {
+  const hasNetworkProjection = Boolean(
+    String(network.interface || "").trim() ||
+    String(network.subnetCidr || "").trim() ||
+    String(network.hostIp || "").trim() ||
+    String(network.dnsServer || "").trim() ||
+    String(network.ntpServer || "").trim() ||
+    typeof network.managed === "boolean" ||
+    typeof network.dhcpEnabled === "boolean" ||
+    typeof network.ntpEnabled === "boolean" ||
+    String(network.timezone || "").trim(),
+  );
+
+  if (cameraInventoryLoading && !hasNetworkProjection) {
+    return `<p class="panelHint">Loading camera network…</p>`;
+  }
+  if (!hasNetworkProjection) {
+    const detail = cameraInventoryError
+      ? escapeHtml(cameraInventoryError)
+      : "Camera network details will appear after gateway inventory resolves.";
+    const toneClass = cameraInventoryError ? "warnText" : "";
+    return `<p class="panelHint ${toneClass}">${detail}</p>`;
+  }
+
+  return `
+    ${renderKvRow("Managed", network.managed ? "yes" : "no")}
+    ${renderKvRow("Interface", String(network.interface || "not configured"))}
+    ${renderKvRow("Subnet", String(network.subnetCidr || "not configured"))}
+    ${renderKvRow("Host IP", String(network.hostIp || "not configured"))}
+    ${renderKvRow("DHCP", network.dhcpEnabled ? `${String(network.dhcpRangeStart || "—")} → ${String(network.dhcpRangeEnd || "—")}` : "disabled")}
+    ${renderKvRow("NTP", network.ntpEnabled ? String(network.ntpServer || "enabled") : "disabled")}
+    ${renderKvRow("Timezone", String(network.timezone || "UTC"))}
+    ${renderKvRow("DNS", String(network.dnsServer || "not configured"))}
+    ${cameraInventoryError ? `<p class="panelHint warnText">${escapeHtml(cameraInventoryError)}</p>` : ""}
+  `;
+}
+
 function renderNvrSettingsSummary(): void {
   if (!nvrSettingsSummaryEl || !launchContext) return;
   const display = launchContext.display || {};
@@ -2379,15 +2762,7 @@ function renderNvrSettingsSummary(): void {
       viewerIsOwner()
         ? `<section class="nestedPanel">
       <div class="summaryLabel">Camera Network</div>
-      ${renderKvRow("Managed", network.managed ? "yes" : "no")}
-      ${renderKvRow("Interface", String(network.interface || "not configured"))}
-      ${renderKvRow("Subnet", String(network.subnetCidr || "not configured"))}
-      ${renderKvRow("Host IP", String(network.hostIp || "not configured"))}
-      ${renderKvRow("DHCP", network.dhcpEnabled ? `${String(network.dhcpRangeStart || "—")} → ${String(network.dhcpRangeEnd || "—")}` : "disabled")}
-      ${renderKvRow("NTP", network.ntpEnabled ? String(network.ntpServer || "enabled") : "disabled")}
-      ${renderKvRow("Timezone", String(network.timezone || "UTC"))}
-      ${renderKvRow("DNS", String(network.dnsServer || "not configured"))}
-      ${cameraInventoryError ? `<p class="panelHint warnText">${escapeHtml(cameraInventoryError)}</p>` : ""}
+      ${renderCameraNetworkSummary(network)}
     </section>`
         : ""
     }
@@ -2872,6 +3247,7 @@ function refreshRuntimeProjectionLabels(): void {
   const cameraCount = cameraCountForContext(launchContext);
   popServicesEl.textContent = `${serviceLabelForContext(launchContext)} (${cameraCount} camera${cameraCount === 1 ? "" : "s"})`;
   popServicesEl.title = launchContext.servicePk;
+  refreshIdentityHandle();
 }
 
 function renderLaunchContextTiles(context: LaunchContext): boolean {
@@ -2901,7 +3277,7 @@ function renderLaunchContextTiles(context: LaunchContext): boolean {
 
 async function loadLaunchContext(): Promise<LaunchContext> {
   const launchId = parseLaunchId();
-  if (!launchId) throw launchError("launch_context", "launch id is missing from the URL");
+  if (!launchId) return await requestDirectEntryLaunchContext();
 
   let fromRuntime: LaunchContext | null = null;
   try {
@@ -2910,7 +3286,19 @@ async function loadLaunchContext(): Promise<LaunchContext> {
     throw launchError("launch_context", String((error as Error)?.message || error || "runtime launch context request failed"));
   }
   if (fromRuntime) return fromRuntime;
-  throw launchError("launch_context", "launch context is unavailable in the shared runtime; reopen this app from Constitute");
+  throw launchError("launch_context", "launch context is unavailable in the shared runtime");
+}
+
+function isDirectEntryIdleLaunchFailure(error: ManagedLaunchError): boolean {
+  if (!directEntryLaunchAttempted) return false;
+  const detail = String(error.detail || "").toLowerCase();
+  return detail.includes("no security cameras service is available")
+    || detail.includes("launch context is unavailable")
+    || detail.includes("shared browser runtime unavailable")
+    || detail.includes("runtime broker unavailable")
+    || detail.includes("runtime broker missing")
+    || detail.includes("link an identity")
+    || detail.includes("device key is not ready");
 }
 
 function sourceIdForTrack(event: RTCTrackEvent): string {
@@ -3158,10 +3546,6 @@ function bindUi(): void {
     renderNotifications();
   });
 
-  closeAppButtonEl.addEventListener("click", () => {
-    void focusShellAndClose();
-  });
-
   btnMenuEl.addEventListener("click", openDrawer);
   btnDrawerCloseEl.addEventListener("click", closeDrawer);
   drawerBackdropEl.addEventListener("click", closeDrawer);
@@ -3169,20 +3553,17 @@ function bindUi(): void {
     if (notificationMenuOpen && !notifMenuEl.contains(event.target as Node) && !btnBellEl.contains(event.target as Node)) {
       closeNotificationMenu();
     }
+    if (accountCenterOpen && !accountCenterMenuEl.contains(event.target as Node) && !accountRailButtonEl.contains(event.target as Node)) {
+      closeAccountCenter();
+    }
   });
 
   connWrapEl.addEventListener("mouseenter", () => connPopoverEl.classList.remove("hidden"));
   connWrapEl.addEventListener("mouseleave", () => connPopoverEl.classList.add("hidden"));
-  identityHandleEl.addEventListener("click", async () => {
-    const identityId = String(launchContext?.identityId || "").trim();
-    if (!identityId) return;
-    try {
-      await navigator.clipboard.writeText(identityId);
-      identityHandleCopied = true;
-      refreshIdentityHandle();
-    } catch {}
+  accountRailButtonEl.addEventListener("click", (event) => {
+    event.stopPropagation();
+    toggleAccountCenter();
   });
-  identityHandleEl.addEventListener("mouseleave", resetIdentityHandleCopyHint);
 
   navButtons.forEach((button) => {
     button.addEventListener("click", () => {
@@ -3250,10 +3631,10 @@ window.addEventListener("beforeunload", () => {
 
 installDiagnosticsBridge();
 applyDiagnosticsMode();
-updateCloseAppButton();
 bindUi();
 renderCameraRefreshStatus();
-setDrawerStatus("Waiting for managed launch context.");
+renderAccountCenter();
+setDrawerStatus("Waiting for account runtime.");
 renderNotifications();
 refreshIdentityHandle();
 syncUiToHash();
@@ -3261,7 +3642,7 @@ syncUiToHash();
 async function bootstrap(): Promise<void> {
   setBootSplash("Connecting");
   setConnectionState("loading", "neutral");
-  setDrawerStatus("Preparing your Constitute NVR view.");
+  setDrawerStatus("Preparing Security Cameras.");
   app.dataset.launchStage = "launch_context";
   appendLog("bootstrapping managed NVR app surface");
   markStartupStage("nvr.boot.start");
@@ -3290,13 +3671,33 @@ async function bootstrap(): Promise<void> {
 
 void bootstrap().catch((error) => {
   const launchFailure = asManagedLaunchError(error, "launch_context");
-  console.error(launchFailure);
   closePeerConnection();
   dismissBootSplash();
-  setConnectionState("error", "bad");
-  setDrawerStatus(launchFailure.detail);
   app.dataset.launchStage = launchFailure.stage;
   const message = launchFailure.detail;
+  if (isDirectEntryIdleLaunchFailure(launchFailure)) {
+    console.warn(launchFailure);
+    setConnectionState("idle", "neutral");
+    const lowerMessage = message.toLowerCase();
+    const accountRequired = lowerMessage.includes("link an identity") || lowerMessage.includes("device key is not ready");
+    const title = accountRequired
+      ? "Account Required"
+      : "No Security Cameras Service";
+    const body = accountRequired
+      ? "Open Account Center to finish onboarding, then Security Cameras will open directly."
+      : "Connect an account with access to an NVR service, then this app will open it directly.";
+    setDrawerStatus(accountRequired
+      ? "Account setup is required before Security Cameras can connect."
+      : "No Security Cameras service is currently available from this account runtime.");
+    setGridEmpty(title, body);
+    addNotification("warn", "Security Cameras unavailable", message, "app");
+    appendLog(`idle [${launchFailure.stage}] ${message}`);
+    void reportServiceStatus("idle", message, launchFailure.stage);
+    return;
+  }
+  console.error(launchFailure);
+  setConnectionState("error", "bad");
+  setDrawerStatus(launchFailure.detail);
   setGridEmpty("Launch Failed", `${launchFailure.stage}: ${message}`);
   addNotification("bad", "Managed launch failed", message, "app");
   appendLog(`fatal [${launchFailure.stage}] ${message}`);

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -70,8 +70,8 @@ export function deriveSessionKey(
 function identitySecretBytes(config: ConnectionConfig): Uint8Array {
   const hex = String(config.identitySecretHex || "").trim();
   if (hex) return hexToBytes(hex);
-  if (config.allowUnsignedHelloMvp) return hexToBytes(ZERO_SECRET_HEX);
-  throw new Error("identity secret is required unless unsigned MVP mode is enabled");
+  if (config.allowUnsignedDebugHello) return hexToBytes(ZERO_SECRET_HEX);
+  throw new Error("identity secret is required unless unsigned local debug mode is enabled");
 }
 
 export function encryptCommand(

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,23 +1,6 @@
-export type NvrShell = {
-  btnBellEl: HTMLButtonElement;
-  notifMenuEl: HTMLElement;
-  btnNotifClearEl: HTMLButtonElement;
-  notifListEl: HTMLDivElement;
-  closeAppButtonEl: HTMLButtonElement;
-  btnMenuEl: HTMLButtonElement;
-  drawerEl: HTMLElement;
-  drawerBackdropEl: HTMLElement;
-  btnDrawerCloseEl: HTMLButtonElement;
-  navButtons: HTMLButtonElement[];
-  identityHandleEl: HTMLSpanElement;
-  connWrapEl: HTMLSpanElement;
-  connStateTextEl: HTMLSpanElement;
-  connPopoverEl: HTMLDivElement;
-  popConnectionEl: HTMLSpanElement;
-  popRelayEl: HTMLSpanElement;
-  popGatewayEl: HTMLSpanElement;
-  popServicesEl: HTMLSpanElement;
-  popConnectionReasonEl: HTMLDivElement;
+import { renderFirstPartyShell, type FirstPartyShell } from "constitute-ui";
+
+export type NvrShell = FirstPartyShell & {
   liveViewEl: HTMLElement;
   historyViewEl: HTMLElement;
   settingsViewEl: HTMLElement;
@@ -29,176 +12,99 @@ export type NvrShell = {
   cameraListEl: HTMLDivElement;
   addCameraButtonEl: HTMLButtonElement;
   cameraRefreshStatusEl: HTMLSpanElement;
-  logPanelEl: HTMLElement;
-  logEl: HTMLPreElement;
 };
 
-function byId<T extends HTMLElement>(id: string): T {
-  const el = document.getElementById(id);
+const NVR_MAIN_HTML = `
+  <section id="liveView" class="activityPanel">
+    <section class="panel">
+      <div class="panelHeader">
+        <h2>Cameras</h2>
+      </div>
+      <div id="cameraGrid" class="cameraGrid">
+        <article class="emptyState">
+          <strong>No Cameras</strong>
+          <p>Open the app directly or through the gateway once the NVR service is available.</p>
+        </article>
+      </div>
+    </section>
+  </section>
+
+  <section id="historyView" class="activityPanel hidden">
+    <section class="panel">
+      <div class="panelHeader">
+        <div>
+          <h2>History</h2>
+          <p id="historyHint" class="panelHint">Recordings and archive access will appear here when history is available.</p>
+        </div>
+      </div>
+      <article class="historyEmptyState emptyStateTight">
+        <strong>No History Yet</strong>
+        <p>There are no recordings to show yet.</p>
+      </article>
+    </section>
+  </section>
+
+  <section id="settingsView" class="activityPanel hidden">
+    <div class="settingsTabs">
+      <button class="settingsTab" type="button" data-settings-tab="nvr">NVR</button>
+      <button class="settingsTab" type="button" data-settings-tab="cameras">Cameras</button>
+    </div>
+
+    <section id="settingsNvrPanel" class="panel settingsPanel hidden">
+      <div class="panelHeader compactHeader">
+        <div>
+          <h2>NVR</h2>
+          <p class="panelHint">Service identity, host gateway, managed network, and current health.</p>
+        </div>
+      </div>
+      <div id="nvrSettingsSummary" class="settingsSummary"></div>
+    </section>
+
+    <section id="settingsCamerasPanel" class="panel settingsPanel hidden">
+      <div class="panelHeader">
+        <div>
+          <h2>Cameras</h2>
+          <p class="panelHint">Mounted cameras, discovery candidates, and driver-backed settings.</p>
+        </div>
+        <div class="cameraHeaderActions">
+          <button id="btnAddCamera" type="button" class="secondary">Refresh Cameras</button>
+          <span id="cameraRefreshStatus" class="cameraRefreshStatus" hidden aria-live="polite"></span>
+        </div>
+      </div>
+      <div id="cameraList" class="cameraList"></div>
+    </section>
+  </section>
+`;
+
+function byId<T extends HTMLElement>(root: ParentNode, id: string): T {
+  const el = root.querySelector(`#${CSS.escape(id)}`);
   if (!el) throw new Error(`missing element #${id}`);
   return el as T;
 }
 
 export function renderShell(app: HTMLDivElement): NvrShell {
-  app.innerHTML = `
-    <header class="topbar">
-      <div class="left">
-        <h1 class="appname">Constitute NVR</h1>
-      </div>
-      <div class="right">
-        <button id="btnBell" class="iconbtn" type="button" aria-label="Notifications">
-          <svg class="bellIcon" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 21a2.5 2.5 0 0 0 2.4-1.8h-4.8A2.5 2.5 0 0 0 12 21Zm7-5.2H5c1.4-1.3 2.2-3.2 2.2-5.2V9.3c0-2.7 1.7-5 4.2-5.8V3a.6.6 0 1 1 1.2 0v.5c2.5.8 4.2 3.1 4.2 5.8v1.3c0 2 .8 3.9 2.2 5.2Z"/>
-          </svg>
-        </button>
-        <button id="btnMenu" class="iconbtn" type="button" aria-label="Open navigation">☰</button>
-      </div>
-    </header>
-
-    <div id="notifMenu" class="menu hidden" aria-label="Notifications menu">
-      <div class="menuHeader">
-        <div class="menuTitle">Notifications</div>
-        <button id="btnNotifClear" class="smallbtn" type="button">Clear</button>
-      </div>
-      <div id="notifList" class="menuList"></div>
-    </div>
-
-    <div id="drawerBackdrop" class="backdrop hidden"></div>
-    <aside id="drawer" class="drawer hidden" aria-label="Navigation drawer">
-      <div class="drawerHeader">
-        <div class="drawerTitle">Menu</div>
-        <button id="btnDrawerClose" class="iconbtn" type="button" aria-label="Close navigation">×</button>
-      </div>
-      <nav class="drawerNav">
-        <button class="navbtn" type="button" data-activity="live">Live</button>
-        <button class="navbtn" type="button" data-activity="history">History</button>
-        <button class="navbtn" type="button" data-activity="settings">Settings</button>
-        <button id="closeAppButton" type="button" class="navbtn" hidden>Return To Constitute</button>
-      </nav>
-      <div class="drawerFooter small muted">
-        <div class="drawerStatusRail">
-          <div class="drawerStatusInline">
-            <span id="identityHandle" class="identityHandle identityHandle-unlinked" title="Identity not linked yet">@unlinked</span>
-            <span id="connWrap" class="connWrap">
-              <span id="connStateText" class="connStateText connStateText-error">Offline</span>
-              <div id="connPopover" class="popover hidden" role="status" aria-live="polite">
-                <div class="popoverTitle">Connection Status</div>
-                <div class="popoverRow"><span class="muted">Overall</span><span id="popConnection">offline</span></div>
-                <div class="popoverRow"><span class="muted">Relay</span><span id="popRelay">offline</span></div>
-                <div class="popoverRow"><span class="muted">Gateway</span><span id="popGateway">unknown</span></div>
-                <div class="popoverRow"><span class="muted">Services</span><span id="popServices">unknown</span></div>
-                <div id="popConnectionReason" class="popoverDetails muted">Waiting for managed launch context.</div>
-              </div>
-            </span>
-          </div>
-        </div>
-      </div>
-    </aside>
-
-    <main class="appMain">
-      <section id="liveView" class="activityPanel">
-        <section class="panel">
-          <div class="panelHeader">
-            <h2>Cameras</h2>
-          </div>
-          <div id="cameraGrid" class="cameraGrid">
-            <article class="emptyState">
-              <strong>No Cameras</strong>
-              <p>Launch the app from Constitute after the NVR service is available.</p>
-            </article>
-          </div>
-        </section>
-      </section>
-
-      <section id="historyView" class="activityPanel hidden">
-        <section class="panel">
-          <div class="panelHeader">
-            <div>
-              <h2>History</h2>
-              <p id="historyHint" class="panelHint">Recordings and archive access will appear here when history is available.</p>
-            </div>
-          </div>
-          <article class="historyEmptyState emptyStateTight">
-            <strong>No History Yet</strong>
-            <p>There are no recordings to show yet.</p>
-          </article>
-        </section>
-      </section>
-
-      <section id="settingsView" class="activityPanel hidden">
-        <div class="settingsTabs">
-          <button class="settingsTab" type="button" data-settings-tab="nvr">NVR</button>
-          <button class="settingsTab" type="button" data-settings-tab="cameras">Cameras</button>
-        </div>
-
-        <section id="settingsNvrPanel" class="panel settingsPanel hidden">
-          <div class="panelHeader compactHeader">
-            <div>
-              <h2>NVR</h2>
-              <p class="panelHint">Service identity, host gateway, managed network, and current health.</p>
-            </div>
-          </div>
-          <div id="nvrSettingsSummary" class="settingsSummary"></div>
-          <div id="logPanel" class="panel nestedPanel diagnostics-hidden">
-            <div class="panelHeader compactHeader">
-              <div>
-                <h2>Session Log</h2>
-                <p class="panelHint">Managed launch and media negotiation details.</p>
-              </div>
-            </div>
-            <pre id="log" class="log"></pre>
-          </div>
-        </section>
-
-        <section id="settingsCamerasPanel" class="panel settingsPanel hidden">
-          <div class="panelHeader">
-            <div>
-              <h2>Cameras</h2>
-              <p class="panelHint">Mounted cameras, discovery candidates, and driver-backed settings.</p>
-            </div>
-            <div class="cameraHeaderActions">
-              <button id="btnAddCamera" type="button" class="secondary">Refresh Cameras</button>
-              <span id="cameraRefreshStatus" class="cameraRefreshStatus" hidden aria-live="polite"></span>
-            </div>
-          </div>
-          <div id="cameraList" class="cameraList"></div>
-        </section>
-      </section>
-    </main>
-  `;
+  const shell = renderFirstPartyShell(app, {
+    appName: "Constitute NVR",
+    navItems: [
+      { id: "live", label: "Live", active: true },
+      { id: "history", label: "History" },
+      { id: "settings", label: "Settings" },
+    ],
+    mainHtml: NVR_MAIN_HTML,
+  });
 
   return {
-    btnBellEl: byId<HTMLButtonElement>("btnBell"),
-    notifMenuEl: byId<HTMLElement>("notifMenu"),
-    btnNotifClearEl: byId<HTMLButtonElement>("btnNotifClear"),
-    notifListEl: byId<HTMLDivElement>("notifList"),
-    closeAppButtonEl: byId<HTMLButtonElement>("closeAppButton"),
-    btnMenuEl: byId<HTMLButtonElement>("btnMenu"),
-    drawerEl: byId<HTMLElement>("drawer"),
-    drawerBackdropEl: byId<HTMLElement>("drawerBackdrop"),
-    btnDrawerCloseEl: byId<HTMLButtonElement>("btnDrawerClose"),
-    navButtons: Array.from(app.querySelectorAll<HTMLButtonElement>(".navbtn")),
-    identityHandleEl: byId<HTMLSpanElement>("identityHandle"),
-    connWrapEl: byId<HTMLSpanElement>("connWrap"),
-    connStateTextEl: byId<HTMLSpanElement>("connStateText"),
-    connPopoverEl: byId<HTMLDivElement>("connPopover"),
-    popConnectionEl: byId<HTMLSpanElement>("popConnection"),
-    popRelayEl: byId<HTMLSpanElement>("popRelay"),
-    popGatewayEl: byId<HTMLSpanElement>("popGateway"),
-    popServicesEl: byId<HTMLSpanElement>("popServices"),
-    popConnectionReasonEl: byId<HTMLDivElement>("popConnectionReason"),
-    liveViewEl: byId<HTMLElement>("liveView"),
-    historyViewEl: byId<HTMLElement>("historyView"),
-    settingsViewEl: byId<HTMLElement>("settingsView"),
-    cameraGridEl: byId<HTMLDivElement>("cameraGrid"),
-    historyHintEl: byId<HTMLParagraphElement>("historyHint"),
+    ...shell,
+    liveViewEl: byId<HTMLElement>(app, "liveView"),
+    historyViewEl: byId<HTMLElement>(app, "historyView"),
+    settingsViewEl: byId<HTMLElement>(app, "settingsView"),
+    cameraGridEl: byId<HTMLDivElement>(app, "cameraGrid"),
+    historyHintEl: byId<HTMLParagraphElement>(app, "historyHint"),
     settingsTabButtons: Array.from(app.querySelectorAll<HTMLButtonElement>(".settingsTab")),
-    nvrSettingsPanelEl: byId<HTMLElement>("settingsNvrPanel"),
-    camerasPanelEl: byId<HTMLElement>("settingsCamerasPanel"),
-    cameraListEl: byId<HTMLDivElement>("cameraList"),
-    addCameraButtonEl: byId<HTMLButtonElement>("btnAddCamera"),
-    cameraRefreshStatusEl: byId<HTMLSpanElement>("cameraRefreshStatus"),
-    logPanelEl: byId<HTMLElement>("logPanel"),
-    logEl: byId<HTMLPreElement>("log"),
+    nvrSettingsPanelEl: byId<HTMLElement>(app, "settingsNvrPanel"),
+    camerasPanelEl: byId<HTMLElement>(app, "settingsCamerasPanel"),
+    cameraListEl: byId<HTMLDivElement>(app, "cameraList"),
+    addCameraButtonEl: byId<HTMLButtonElement>(app, "btnAddCamera"),
+    cameraRefreshStatusEl: byId<HTMLSpanElement>(app, "cameraRefreshStatus"),
   };
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -50,42 +50,10 @@ textarea {
   }
 }
 
-.topbar {
-  position: sticky;
-  top: 0;
-  z-index: 40;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  background: linear-gradient(to bottom, rgba(15, 21, 33, 0.95), rgba(15, 21, 33, 0.8));
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-}
-
-.left,
-.right {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-}
-
-.appname {
-  margin: 0;
-  font-size: 1.45rem;
-  font-weight: 800;
-  letter-spacing: 0.02em;
-}
-
-.iconbtn,
 .secondary,
 .badge,
-.navbtn,
 .settingsTab,
 .cameraActionButton,
-.smallbtn,
 .permissionChip,
 .cameraCapabilityChip {
   border: 1px solid var(--line);
@@ -93,16 +61,12 @@ textarea {
   color: var(--text);
 }
 
-.iconbtn,
 .secondary,
-.navbtn,
 .settingsTab,
-.smallbtn,
 .cameraActionButton {
   cursor: pointer;
 }
 
-.iconbtn,
 .cameraActionButton {
   border-radius: 12px;
   padding: 0.45rem 0.6rem;
@@ -114,16 +78,12 @@ textarea {
 }
 
 .secondary,
-.navbtn,
-.settingsTab,
-.smallbtn {
+.settingsTab {
   border-radius: 999px;
   padding: 0.55rem 0.95rem;
 }
 
-.iconbtn:hover,
 .secondary:hover,
-.navbtn:hover,
 .settingsTab:hover,
 .cameraActionButton:hover {
   border-color: rgba(87, 209, 191, 0.35);
@@ -146,201 +106,9 @@ textarea {
 .badge-good { color: var(--good); border-color: rgba(89, 211, 145, 0.35); }
 .badge-bad { color: var(--bad); border-color: rgba(240, 113, 122, 0.35); }
 
-.backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.55);
-  z-index: 50;
-}
-
-.drawer {
-  position: fixed;
-  top: 0;
-  right: 0;
-  z-index: 60;
-  width: min(360px, calc(100vw - 1rem));
-  height: 100%;
-  padding: 0.85rem;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  background: rgba(15, 21, 33, 0.98);
-  border-left: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32);
-}
-
-.drawerHeader,
-.drawerFooter,
-.drawerStatusHeader {
-  display: grid;
-  gap: 0.3rem;
-}
-
-.drawerHeader {
-  grid-template-columns: 1fr auto;
-  align-items: center;
-}
-
-.drawerTitle {
-  font-weight: 800;
-}
-
-.drawerNav {
-  display: grid;
-  gap: 0.5rem;
-}
-
-.navbtn.active,
 .settingsTab.active {
   color: var(--accent);
   border-color: rgba(87, 209, 191, 0.35);
-}
-
-.drawerFooter {
-  margin-top: auto;
-  padding-top: 1rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.drawerStatusRail {
-  margin-top: 0.2rem;
-}
-
-.drawerStatusInline {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.85rem;
-}
-
-.identityHandle {
-  color: var(--muted);
-  user-select: none;
-  white-space: nowrap;
-}
-
-.identityHandle-linked {
-  color: var(--accent);
-}
-
-.identityHandle-unlinked {
-  color: var(--warn);
-}
-
-.menu {
-  position: absolute;
-  top: 60px;
-  right: 16px;
-  width: min(360px, calc(100vw - 1rem));
-  background: rgba(18, 23, 38, 0.98);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 16px;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32);
-  z-index: 80;
-  padding: 0.6rem;
-}
-
-.menu.hidden {
-  display: none;
-}
-
-.menuHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 0.25rem 0.2rem 0.6rem;
-}
-
-.menuTitle {
-  font-weight: 700;
-}
-
-.menuList {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  max-height: 420px;
-  overflow: auto;
-}
-
-.bellIcon {
-  width: 20px;
-  height: 20px;
-  display: block;
-}
-
-.bellIcon path {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.6;
-}
-
-.iconbtn.has-unread .bellIcon path {
-  fill: var(--accent);
-  stroke: var(--accent);
-}
-
-.connWrap {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-end;
-  min-width: max-content;
-}
-
-.connStateText {
-  font-size: 0.82rem;
-  color: var(--muted);
-  font-weight: 600;
-  user-select: none;
-}
-
-.connStateText-connected {
-  color: var(--accent);
-}
-
-.connStateText-limited {
-  color: var(--warn);
-}
-
-.connStateText-error {
-  color: var(--bad);
-}
-
-.popover {
-  position: absolute;
-  right: 0;
-  bottom: calc(100% + 10px);
-  width: 280px;
-  background: rgba(18, 23, 38, 0.98);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 14px;
-  padding: 0.7rem;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32);
-  z-index: 90;
-}
-
-.popover.hidden {
-  display: none;
-}
-
-.popoverTitle {
-  font-weight: 700;
-  margin-bottom: 0.5rem;
-}
-
-.popoverRow {
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.9rem;
-  margin: 0.25rem 0;
-}
-
-.popoverDetails {
-  font-size: 0.82rem;
-  margin: 0.5rem 0 0;
-  word-break: break-word;
-  line-height: 1.4;
 }
 
 .drawerStatusLabel {
@@ -943,40 +711,17 @@ textarea {
   }
 }
 
-.log {
-  margin: 0;
-  min-height: 180px;
-  max-height: 320px;
-  overflow: auto;
-  padding: 0.9rem;
-  border-radius: 0.9rem;
-  background: rgba(2, 6, 12, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.04);
-  color: #d7e0ef;
-  font: 0.85rem/1.5 var(--mono);
-  white-space: pre-wrap;
-}
-
-.diagnostics-hidden {
-  display: none !important;
-}
-
 @media (max-width: 760px) {
   .appMain {
     width: min(100vw - 1rem, 100%);
     padding-top: 0.8rem;
   }
 
-  .topbar,
   .panelHeader,
   .cameraHeader,
   .permissionCameraRow {
     flex-direction: column;
     align-items: stretch;
-  }
-
-  .right {
-    justify-content: flex-end;
   }
 
   .cameraGrid {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export type ConnectionConfig = {
   identityId: string;
   devicePk: string;
   identitySecretHex: string;
-  allowUnsignedHelloMvp?: boolean;
+  allowUnsignedDebugHello?: boolean;
 };
 
 export type HelloRequest = {

--- a/tests/managed-launch.spec.ts
+++ b/tests/managed-launch.spec.ts
@@ -45,6 +45,21 @@ type LaunchContext = {
 
 type RuntimeMockConfig = {
   launchContext: LaunchContext | null;
+  brokerLaunchContext?: LaunchContext | null;
+  failDirectLaunchMessage?: string;
+  directLaunchDelayMs?: number;
+  managedAppliances?: {
+    owned?: Array<Record<string, unknown>>;
+    granted?: Array<Record<string, unknown>>;
+    discoverable?: Array<Record<string, unknown>>;
+  };
+  initialShell?: Record<string, unknown> | null;
+  bridgeManagedAppliances?: {
+    owned?: Array<Record<string, unknown>>;
+    granted?: Array<Record<string, unknown>>;
+    discoverable?: Array<Record<string, unknown>>;
+  };
+  bridgeHydrationDelayMs?: number;
   diagnostics?: boolean;
   expireOfferPreflight?: boolean;
   ownerInventory?: boolean;
@@ -120,6 +135,34 @@ function buildLaunchContext(overrides: Partial<LaunchContext> = {}): LaunchConte
   };
 }
 
+function buildNvrManagedAppliances(context = buildLaunchContext()) {
+  const serviceRecord = {
+    devicePk: context.servicePk,
+    deviceLabel: context.display?.serviceLabel || "Lab NVR",
+    deviceKind: "service",
+    role: "nvr",
+    service: "nvr",
+    hostGatewayPk: context.gatewayPk,
+    serviceVersion: context.display?.serviceVersion || "0.2.0",
+    updatedAt: Date.now(),
+  };
+  return {
+    owned: [
+      {
+        devicePk: context.gatewayPk,
+        deviceLabel: "Lab Gateway",
+        role: "gateway",
+        service: "gateway",
+        updatedAt: Date.now(),
+        hostedServices: [serviceRecord],
+      },
+      serviceRecord,
+    ],
+    granted: [],
+    discoverable: [],
+  };
+}
+
 async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
   launchContext: buildLaunchContext(),
   diagnostics: false,
@@ -134,6 +177,7 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
     }
 
     const launchId = String(runtimeConfig.launchContext?.launchId || "launch-test-001");
+    let activeLaunchId = launchId;
     const initialContext = runtimeConfig.launchContext ? structuredClone(runtimeConfig.launchContext) : null;
     let currentLaunchToken = String(initialContext?.launchToken || "launch-token-001");
     let launchRefreshCount = 0;
@@ -145,6 +189,11 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
     let failNextAdmin = false;
     const workerPorts = new Set<MockMessagePort>();
     let lastPeerConnection: MockRTCPeerConnection | null = null;
+    let currentManagedAppliances = runtimeConfig.managedAppliances || {
+      owned: [],
+      granted: [],
+      discoverable: [],
+    };
 
     const mutableCameras = new Map(
       Array.isArray(initialContext?.display?.cameras)
@@ -258,6 +307,7 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
     const runtimeState = {
       launchContexts: new Map<string, LaunchContext>(),
       services: {} as Record<string, unknown>,
+      shell: runtimeConfig.initialShell || null as Record<string, unknown> | null,
       resourceNames: {} as Record<string, string>,
     };
 
@@ -270,15 +320,11 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
 
     function runtimeSnapshot() {
       return {
-        buildId: "runtime-2.8",
+        buildId: "runtime-2.9",
         updatedAt: Date.now(),
-        shell: null,
+        shell: runtimeState.shell,
         services: runtimeState.services,
-        managedAppliances: {
-          owned: [],
-          granted: [],
-          discoverable: [],
-        },
+        managedAppliances: currentManagedAppliances,
         resourceNames: runtimeState.resourceNames,
         managedServiceIssue: null,
         launchContextCount: runtimeState.launchContexts.size,
@@ -332,7 +378,7 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
         if (type === "runtime.attach") {
           this.emit({
             type: "runtime.attached",
-            buildId: "runtime-2.8",
+            buildId: "runtime-2.9",
             snapshot: runtimeSnapshot(),
           });
           return;
@@ -344,9 +390,14 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
           this.emit(runtimeResponse(requestId, runtimeSnapshot(), "runtime.status.put"));
           this.emit({
             type: "runtime.snapshot",
-            buildId: "runtime-2.8",
+            buildId: "runtime-2.9",
             snapshot: runtimeSnapshot(),
           });
+          return;
+        }
+
+        if (type === "runtime.snapshot.get") {
+          this.emit(runtimeResponse(requestId, runtimeSnapshot(), "runtime.snapshot.get"));
           return;
         }
 
@@ -365,11 +416,12 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
           if (context?.launchId) {
             runtimeState.launchContexts.set(context.launchId, structuredClone(context));
             currentLaunchToken = context.launchToken;
+            activeLaunchId = context.launchId;
           }
           this.emit(runtimeResponse(requestId, context, "launchContext.put"));
           this.emit({
             type: "runtime.snapshot",
-            buildId: "runtime-2.8",
+            buildId: "runtime-2.9",
             snapshot: runtimeSnapshot(),
           });
           return;
@@ -377,30 +429,39 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
 
         if (type === "gateway.launch.request") {
           launchRefreshCount += 1;
-          const context = runtimeState.launchContexts.get(launchId);
-          if (!context) {
-            this.emit(runtimeError(requestId, "launch context unavailable", "gateway.launch.request"));
-            return;
-          }
-          currentLaunchToken = `launch-token-${launchRefreshCount + 1}`;
-          const refreshedContext: LaunchContext = {
-            ...context,
-            launchToken: currentLaunchToken,
-            createdAt: Date.now(),
-            expiresAt: Date.now() + 60_000,
+          const respond = () => {
+            if (runtimeConfig.failDirectLaunchMessage) {
+              this.emit(runtimeError(requestId, runtimeConfig.failDirectLaunchMessage, "gateway.launch.request"));
+              return;
+            }
+            const context = runtimeState.launchContexts.get(launchId);
+            const directContext = runtimeConfig.brokerLaunchContext || null;
+            const selectedContext = context || directContext;
+            if (!selectedContext) {
+              this.emit(runtimeError(requestId, "launch context unavailable", "gateway.launch.request"));
+              return;
+            }
+            currentLaunchToken = `launch-token-${launchRefreshCount + 1}`;
+            const refreshedContext: LaunchContext = {
+              ...selectedContext,
+              launchToken: currentLaunchToken,
+              createdAt: Date.now(),
+              expiresAt: Date.now() + 60_000,
+            };
+            if (context) runtimeState.launchContexts.set(launchId, refreshedContext);
+            this.emit(runtimeResponse(requestId, {
+              requestId,
+              gatewayPk: refreshedContext.gatewayPk,
+              servicePk: refreshedContext.servicePk,
+              service: refreshedContext.service,
+              capability: "nvr.view",
+              launchToken: refreshedContext.launchToken,
+              display: refreshedContext.display,
+              expiresAt: refreshedContext.expiresAt,
+              ts: Date.now(),
+            }, "gateway.launch.request"));
           };
-          runtimeState.launchContexts.set(launchId, refreshedContext);
-          this.emit(runtimeResponse(requestId, {
-            requestId,
-            gatewayPk: refreshedContext.gatewayPk,
-            servicePk: refreshedContext.servicePk,
-            service: refreshedContext.service,
-            capability: "nvr.view",
-            launchToken: refreshedContext.launchToken,
-            display: refreshedContext.display,
-            expiresAt: refreshedContext.expiresAt,
-            ts: Date.now(),
-          }, "gateway.launch.request"));
+          window.setTimeout(respond, Math.max(0, Number(runtimeConfig.directLaunchDelayMs || 0)));
           return;
         }
 
@@ -427,7 +488,7 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
             : {};
           const signalType = String(root.signalType || "");
           const signalRequestId = String(root.requestId || requestId || "signal-request");
-          const context = runtimeState.launchContexts.get(launchId);
+          const context = runtimeState.launchContexts.get(activeLaunchId);
           if (!context) {
             this.emit(runtimeError(requestId, "launch context unavailable", "gateway.signal.request"));
             return;
@@ -642,6 +703,35 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
       }
     }
 
+    const nativeAppendChild = Element.prototype.appendChild;
+    Element.prototype.appendChild = function appendChildWithAccountBridgeHydration<T extends Node>(node: T): T {
+      const appended = nativeAppendChild.call(this, node) as T;
+      if (
+        node instanceof HTMLIFrameElement
+        && String(node.id || "") === "constituteAccountBridge"
+        && runtimeConfig.bridgeManagedAppliances
+      ) {
+        window.setTimeout(() => {
+          currentManagedAppliances = runtimeConfig.bridgeManagedAppliances || currentManagedAppliances;
+          runtimeState.shell = {
+            identity: {
+              linked: true,
+              identityId: "identity-test-001",
+              label: "tester",
+            },
+          };
+          for (const port of workerPorts) {
+            port.dispatch({
+              type: "runtime.snapshot",
+              buildId: "runtime-2.9",
+              snapshot: runtimeSnapshot(),
+            });
+          }
+        }, Math.max(0, Number(runtimeConfig.bridgeHydrationDelayMs || 0)));
+      }
+      return appended;
+    };
+
     Object.defineProperty(window, "SharedWorker", {
       configurable: true,
       writable: true,
@@ -685,7 +775,7 @@ async function installRuntimeHarness(page: Page, config: RuntimeMockConfig = {
           for (const port of workerPorts) {
             port.dispatch({
               type: "runtime.snapshot",
-              buildId: "runtime-2.8",
+              buildId: "runtime-2.9",
               snapshot: runtimeSnapshot(),
             });
           }
@@ -701,7 +791,7 @@ test("boots from runtime launch context and renders a live camera grid", async (
   await installRuntimeHarness(page);
   await page.goto("/#launch=launch-test-001");
 
-  await expect(page.getByRole("heading", { name: "Constitute NVR" })).toBeVisible();
+  await expect(page.locator("#appName")).toHaveText("Constitute NVR");
   await expect(page.locator("#liveView .panelHeader h2")).toHaveText("Cameras");
   await expect(page.locator("#subtitle")).toHaveCount(0);
   await expect(page.locator("#summaryPanel")).toHaveCount(0);
@@ -827,66 +917,13 @@ test("binds each preview tile to its own track even when remote tracks share one
   expect(trackBinding[0]?.trackIds[0]).not.toBe(trackBinding[1]?.trackIds[0]);
 });
 
-test("hides the close affordance when no shell opener is available", async ({ page }) => {
+test("does not expose opener-return actions in the shared account center", async ({ page }) => {
   await installRuntimeHarness(page);
   await page.goto("/#launch=launch-test-001");
 
-  await expect(page.getByRole("button", { name: "Return To Constitute" })).toHaveCount(0);
-});
-
-test("focuses the shell opener and closes when launched from the shell", async ({ page }) => {
-  await installRuntimeHarness(page);
-  await page.addInitScript(() => {
-    let focused = false;
-    let closeRequested = false;
-    const opener = {
-      closed: false,
-      focus() {
-        focused = true;
-      },
-    };
-
-    Object.defineProperty(window, "opener", {
-      configurable: true,
-      get: () => opener,
-    });
-
-    Object.defineProperty(window, "close", {
-      configurable: true,
-      writable: true,
-      value: () => {
-        closeRequested = true;
-      },
-    });
-
-    Object.defineProperty(window, "__closeProbe", {
-      configurable: true,
-      value: {
-        get focused() {
-          return focused;
-        },
-        get closeRequested() {
-          return closeRequested;
-        },
-      },
-    });
-  });
-
-  await page.goto("/#launch=launch-test-001");
-
-  await page.getByRole("button", { name: "Open navigation" }).click();
-  const closeButton = page.getByRole("button", { name: "Return To Constitute" });
-  await expect(closeButton).toBeVisible();
-  await closeButton.click();
-
-  await expect.poll(async () => {
-    return await page.evaluate(() => {
-      const probe = (window as Window & {
-        __closeProbe?: { focused: boolean; closeRequested: boolean };
-      }).__closeProbe;
-      return probe ? `${probe.focused}:${probe.closeRequested}` : "false:false";
-    });
-  }).toBe("true:true");
+  await page.getByRole("button", { name: "Menu" }).click();
+  await page.locator("#accountRailButton").click();
+  await expect(page.getByRole("button", { name: "Return To Opener" })).toHaveCount(0);
 });
 
 test("refreshes launch token through the shared runtime before offer", async ({ page }) => {
@@ -912,18 +949,151 @@ test("refreshes launch token through the shared runtime before offer", async ({ 
   }).toBe("1:launch-token-2");
 });
 
-test("shows a clear launch failure when runtime has no launch context", async ({ page }) => {
+test("direct app entry launches an available NVR service from the shared runtime", async ({ page }) => {
+  const context = buildLaunchContext();
   await installRuntimeHarness(page, {
     launchContext: null,
+    brokerLaunchContext: context,
+    managedAppliances: buildNvrManagedAppliances(context),
     diagnostics: false,
     expireOfferPreflight: false,
     ownerInventory: false,
   });
 
-  await page.goto("/#launch=launch-test-001");
+  await page.goto("/");
 
-  await expect(page.locator(".emptyState strong")).toHaveText("Launch Failed");
-  await expect(page.locator(".emptyState p")).toContainText("launch context is unavailable");
+  await expect(page.locator(".cameraTile")).toHaveCount(2);
+  await expect(page.locator("#connStateText")).toHaveText("live");
+  await expect.poll(async () => {
+    return await page.evaluate(() => {
+      const probe = (window as Window & {
+        __runtimeProbe?: { launchRefreshCount: number; currentLaunchToken: string };
+      }).__runtimeProbe;
+      return probe ? `${probe.launchRefreshCount}:${probe.currentLaunchToken}` : "0:";
+    });
+  }).toBe("1:launch-token-2");
+});
+
+test("direct app entry hydrates account bridge before deciding service availability", async ({ page }) => {
+  const context = buildLaunchContext();
+  await installRuntimeHarness(page, {
+    launchContext: null,
+    brokerLaunchContext: context,
+    bridgeManagedAppliances: buildNvrManagedAppliances(context),
+    bridgeHydrationDelayMs: 150,
+    diagnostics: false,
+    expireOfferPreflight: false,
+    ownerInventory: false,
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator("#constituteAccountBridge")).toHaveCount(1);
+  await expect(page.locator(".cameraTile")).toHaveCount(2);
+  await expect(page.locator("#connStateText")).toHaveText("live");
+  await expect.poll(async () => {
+    return await page.evaluate(() => {
+      const probe = (window as Window & {
+        __runtimeProbe?: { launchRefreshCount: number; currentLaunchToken: string };
+      }).__runtimeProbe;
+      return probe ? `${probe.launchRefreshCount}:${probe.currentLaunchToken}` : "0:";
+    });
+  }).toBe("1:launch-token-2");
+});
+
+test("direct app entry waits out the account bridge settle window before treating identity as unlinked", async ({ page }) => {
+  const context = buildLaunchContext();
+  await installRuntimeHarness(page, {
+    launchContext: null,
+    brokerLaunchContext: context,
+    initialShell: {
+      identity: {
+        linked: false,
+      },
+    },
+    bridgeManagedAppliances: buildNvrManagedAppliances(context),
+    bridgeHydrationDelayMs: 150,
+    diagnostics: false,
+    expireOfferPreflight: false,
+    ownerInventory: false,
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator("#constituteAccountBridge")).toHaveCount(1);
+  await expect(page.locator(".cameraTile")).toHaveCount(2);
+  await expect(page.locator(".emptyState strong")).toHaveCount(0);
+  await expect(page.locator("#connStateText")).toHaveText("live");
+});
+
+test("direct app entry waits past the old refresh timeout for first session authorization", async ({ page }) => {
+  test.setTimeout(45_000);
+  const context = buildLaunchContext();
+  await installRuntimeHarness(page, {
+    launchContext: null,
+    brokerLaunchContext: context,
+    managedAppliances: buildNvrManagedAppliances(context),
+    directLaunchDelayMs: 21_000,
+    diagnostics: false,
+    expireOfferPreflight: false,
+    ownerInventory: false,
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator(".emptyState strong")).toHaveText("Launching Security Cameras");
+  await expect(page.locator("#connStateText")).toHaveText("launching");
+  await expect(page.locator(".cameraTile")).toHaveCount(2, { timeout: 30_000 });
+  await expect(page.locator("#connStateText")).toHaveText("live");
+});
+
+test("direct app entry stays inside the NVR app when no service is available", async ({ page }) => {
+  await installRuntimeHarness(page, {
+    launchContext: null,
+    bridgeManagedAppliances: {
+      owned: [],
+      granted: [],
+      discoverable: [],
+    },
+    diagnostics: false,
+    expireOfferPreflight: false,
+    ownerInventory: false,
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator(".emptyState strong")).toHaveText("No Security Cameras Service");
+  await expect(page.locator(".emptyState p")).toContainText("this app will open it directly");
+  await expect(page.locator(".emptyState p")).not.toContainText("constitute-gateway-ui");
+  await expect(page.locator(".emptyState p")).not.toContainText("managed launch URL");
+  await expect(page.locator("#connStateText")).toHaveText("idle");
+});
+
+test("direct app entry treats transient gateway launch failure as recoverable app state", async ({ page }) => {
+  const context = buildLaunchContext();
+  await installRuntimeHarness(page, {
+    launchContext: null,
+    brokerLaunchContext: context,
+    managedAppliances: buildNvrManagedAppliances(context),
+    failDirectLaunchMessage: "transient gateway launch failure",
+    diagnostics: false,
+    expireOfferPreflight: false,
+    ownerInventory: false,
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator(".emptyState strong")).toHaveText("Launching Security Cameras");
+  await expect(page.locator(".emptyState p")).toContainText("Resolving an account-authorized camera session");
+  await expect(page.locator("#connStateText")).toHaveText("launching");
+  await expect.poll(async () => {
+    return await page.evaluate(() => {
+      const probe = (window as Window & {
+        __runtimeProbe?: { launchRefreshCount: number };
+      }).__runtimeProbe;
+      return probe?.launchRefreshCount || 0;
+    });
+  }).toBeGreaterThan(1);
 });
 
 test("settings use NVR and Cameras tabs only", async ({ page }) => {
@@ -933,6 +1103,7 @@ test("settings use NVR and Cameras tabs only", async ({ page }) => {
   await expect(page.getByRole("button", { name: "NVR" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Cameras" })).toBeVisible();
   await expect(page.getByRole("button", { name: "Permissions" })).toHaveCount(0);
+  await expect(page.getByRole("heading", { name: "Session Log" })).toHaveCount(0);
 });
 
 test("camera settings use site time policy and do not expose per-camera time controls", async ({ page }) => {
@@ -1274,7 +1445,8 @@ test("keeps the expanded camera card mounted when inventory refresh fails", asyn
   await expect(cameraCard).toBeVisible();
   await expect(tray).toBeVisible();
   await expect(page.locator(".cameraList > .emptyState")).toHaveCount(0);
-  await expect(page.locator(".menuList")).toContainText("Camera inventory unavailable");
+  await page.getByRole("button", { name: "Notifications" }).click();
+  await expect(page.locator("#notifList")).toContainText("Camera inventory unavailable");
 });
 
 test("apply camera settings stays mounted while the request is pending", async ({ page }) => {


### PR DESCRIPTION
## Summary
- migrate the NVR app surface to the `constitute-account` runtime path and shared `constitute-ui` shell
- retire bespoke opener/back affordances and use shared account-state chrome
- make direct NVR entry resolve account/runtime state without requiring a prior manual account visit
- keep launch/signaling/media failure scoped after usable app structure exists
- add browser coverage for direct-entry delay/retry and shared-shell behavior

## Validation
- `npm run build`
- `npm run test:e2e`
- aggregate local build pass
- aggregate local test pass

Closes #13
