### PR TITLE
Adopt NVR surface contract posture

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import {
   runtimeRouteObservationPosture,
   runtimeStreamSessionPosture as summarizeRuntimeStreamSessionPosture,
 } from "../../constitute-ui/src/runtime-stream-session.js";
+import { preparedServiceRegistryServices } from "../../constitute-ui/src/service-registry-model.js";
 import {
   applyBrowserStreamAnswer,
   applyBrowserStreamCandidate,
@@ -2759,10 +2760,7 @@ function directEntryNvrServiceRecord(snapshot: RuntimeSnapshot | null): ManagedA
 }
 
 function directEntryNvrServiceCatalogRecord(snapshot: RuntimeSnapshot | null): ManagedApplianceRecord | null {
-  const catalog = snapshot?.serviceCatalog && typeof snapshot.serviceCatalog === "object"
-    ? snapshot.serviceCatalog as Record<string, unknown>
-    : null;
-  const services = Array.isArray(catalog?.services) ? catalog.services : [];
+  const services = preparedServiceRegistryServices((snapshot || {}) as Record<string, unknown>);
   const match = services.find((entry) => {
     if (!entry || typeof entry !== "object") return false;
     return normalizeRole((entry as Record<string, unknown>).service) === "nvr";

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import { renderActionList, setConnectionStateText } from "constitute-ui";
 import { createKeyValueGrid } from "../../constitute-ui/src/index.js";
 import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
 import { renderShell } from "./shell";
+import { nvrSurfaceAttachContext } from "./surface-app-contract.js";
 import {
   PLATFORM_RUNTIME_BUILD_ID as RUNTIME_WORKER_BUILD_ID,
   RUNTIME_AUTHORITY_POSTURE_GET,
@@ -1329,6 +1330,7 @@ async function ensureRuntimePort(): Promise<MessagePort | null> {
       debug: diagnosticsEnabled,
       debugInfo: runtimeAttachDebugInfo(window.location.origin),
       logPrefix: "nvr-ui",
+      attachContext: nvrSurfaceAttachContext,
       onPort: (port) => {
         runtimePort = port as MessagePort;
         runtimeAttached = false;

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,0 +1,106 @@
+import { SURFACE_APP, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
+import { defineSurfaceAppContract } from "../../constitute-ui/src/surface-app-contract.js";
+
+const ISSUED_AT = 1700000000;
+
+export const nvrSurfaceAppContract = assertSurfaceAppContract({
+  contractId: "surface-app:constitute-nvr-ui",
+  schemaVersion: SURFACE_APP.SCHEMA_VERSION,
+  appId: "constitute-nvr-ui",
+  appRef: "app:nvr-ui",
+  serviceRef: "service:nvr",
+  surfaceRef: "surface:nvr-ui",
+  version: "0.2.0",
+  displayName: "Security Cameras",
+  requiredPrimitives: [
+    "runtime.attach",
+    "projection.materialization",
+    "stream.intent",
+    "media.transport.path",
+  ],
+  requiredModuleRoles: [
+    SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+    SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER,
+    SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+  ],
+  modules: [
+    {
+      moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["runtime.attach", "runtime.stream.open", "runtime.stream.control"],
+      inputs: ["runtime.snapshot", "runtime.stream.answer"],
+      outputs: ["runtime.intent", "media.fulfillment.evidence"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-nvr-ui/nvr-projection-model@0.2.0",
+      role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.2.0",
+      primitiveRefs: ["projection.materialization", "camera.inventory"],
+      inputs: ["runtime.snapshot", "nvr.inventory"],
+      outputs: ["camera.read-model"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
+      role: SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.1.0",
+      primitiveRefs: ["media.transport.path"],
+      inputs: ["runtime.stream.answer", "media.transport.profile"],
+      outputs: ["media.transport.observation", "media.fulfillment.evidence"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
+      role: SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.2.0",
+      primitiveRefs: ["stream.intent", "service.surface.admin"],
+      inputs: ["camera.selection", "camera.admin.intent"],
+      outputs: ["runtime.intent"],
+      issuedAt: ISSUED_AT,
+    },
+    {
+      moduleRef: "constitute-nvr-ui/product-view@0.2.0",
+      role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+      participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+      fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      version: "0.2.0",
+      primitiveRefs: ["runtime.posture.render", "media.render.bind"],
+      inputs: ["camera.read-model", "media.render.posture"],
+      outputs: ["user.intent"],
+      issuedAt: ISSUED_AT,
+    },
+  ],
+  projectionSubscriptions: [
+    { projectionId: "nvr.inventory", channelId: "nvr.inventory" },
+    { projectionId: "nvr.streams", channelId: "nvr.streams" },
+  ],
+  materializationBudgets: [
+    { budgetId: "nvr-ui.preview", maxItems: 2 },
+    { budgetId: "nvr-ui.stream-events", maxItems: 240 },
+  ],
+  updatePosture: {
+    state: SURFACE_APP.UPDATE_POSTURE.STATIC,
+    checkedAt: ISSUED_AT,
+  },
+  issuedAt: ISSUED_AT,
+});
+
+export const nvrSurfaceApp = defineSurfaceAppContract(nvrSurfaceAppContract, {
+  validate: assertSurfaceAppContract,
+});
+
+export const nvrSurfaceAttachContext = nvrSurfaceApp.attachContext({
+  productSurface: "constitute-nvr-ui",
+});

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -112,6 +112,8 @@ test("nvr ui attaches to the account-owned runtime worker contract", () => {
 
   assert.match(main, /createRuntimeSurfaceClient/);
   assert.match(main, /from "\.\.\/\.\.\/constitute-ui\/src\/runtime-surface-client\.js"/);
+  assert.match(main, /from "\.\/surface-app-contract\.js"/);
+  assert.match(main, /attachContext: nvrSurfaceAttachContext/);
   assert.match(main, /from "\.\.\/\.\.\/constitute-account\/runtime-contract\.js"/);
   assert.match(main, /PLATFORM_RUNTIME_BUILD_ID as RUNTIME_WORKER_BUILD_ID/);
   assert.match(main, /RUNTIME_STREAM_OPEN/);
@@ -131,6 +133,18 @@ test("nvr ui attaches to the account-owned runtime worker contract", () => {
   assert.doesNotMatch(main, /runtimeReadyPromise/);
   assert.doesNotMatch(main, /RUNTIME_WORKER_VERSION = Object\.freeze/);
   assert.doesNotMatch(main, /constitute-account-runtime-\$\{RUNTIME_WORKER_BUILD_ID\}/);
+});
+
+test("nvr ui declares a surface app contract", async () => {
+  const { nvrSurfaceApp, nvrSurfaceAttachContext } = await import("../src/surface-app-contract.js");
+  assert.equal(nvrSurfaceApp.posture.state, "ready");
+  assert.equal(nvrSurfaceApp.hasRole("runtimeClient"), true);
+  assert.equal(nvrSurfaceApp.hasRole("projectionModel"), true);
+  assert.equal(nvrSurfaceApp.hasRole("platformAdapter"), true);
+  assert.equal(nvrSurfaceApp.hasRole("serviceSurfaceAdapter"), true);
+  assert.equal(nvrSurfaceApp.hasRole("productView"), true);
+  assert.equal(nvrSurfaceAttachContext.kind, "surface.app.attachContext");
+  assert.equal(nvrSurfaceAttachContext.appId, "constitute-nvr-ui");
 });
 
 test("nvr service administration uses a service-surface adapter boundary", () => {


### PR DESCRIPTION
Declares the NVR UI surface contract and resolves NVR service identity through registry posture. NVR UI continues to move toward narrow intent emission and shared runtime/media posture consumption.\n\nValidation: root docs/convergence/affected/browser/native/check:all passed before branch publication; live NVR and 10-minute stream proof passed against the convergence train.