### PR TITLE
Preserve stream recovery media binding

### DIFF
--- a/src/browser-stream-adapter.ts
+++ b/src/browser-stream-adapter.ts
@@ -5,6 +5,7 @@ export {
   MEDIA_RENDER_WAITING_GRACE_MS,
   applyBrowserStreamAnswer,
   applyBrowserStreamCandidate,
+  bindBrowserMediaStream,
   browserStreamAvailable,
   candidateJson,
   candidateKey,
@@ -26,6 +27,7 @@ export {
 export type {
   BrowserStreamAdapterOptions,
   BrowserStreamAdapterState,
+  BrowserMediaStreamBindResult,
   BrowserStreamOffer,
   BrowserStreamSession,
   RuntimeMediaTransportProfile,

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,9 @@ import "./styles.css";
 import { renderActionList, setConnectionStateText } from "constitute-ui";
 import { createKeyValueGrid } from "../../constitute-ui/src/index.js";
 import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
+import { requireSurfaceModuleRole } from "../../constitute-ui/src/surface-app-contract.js";
 import { renderShell } from "./shell";
-import { nvrSurfaceAttachContext } from "./surface-app-contract.js";
+import { nvrSurfaceApp, nvrSurfaceAttachContext } from "./surface-app-contract.js";
 import {
   PLATFORM_RUNTIME_BUILD_ID as RUNTIME_WORKER_BUILD_ID,
   RUNTIME_AUTHORITY_POSTURE_GET,
@@ -76,12 +77,33 @@ import {
   type RuntimeServiceDisplay,
 } from "./nvr-projection-model";
 import {
+  SURFACE_APP,
   STREAM_SESSION_LIFECYCLE_PHASE,
   SWARM,
   streamSessionLifecycleRecordFromCarrier,
   type MediaFulfillmentEvidence,
   type MediaTransportObservation,
 } from "../../constitute-protocol/src/index.js";
+
+const nvrSurfaceModules = Object.freeze({
+  runtimeClient: requireSurfaceModuleRole(nvrSurfaceApp, SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT, {
+    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+    primitiveRef: "runtime.attach",
+  }),
+  platformAdapter: requireSurfaceModuleRole(nvrSurfaceApp, SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER, {
+    moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
+    primitiveRef: "media.transport.path",
+  }),
+  serviceSurfaceAdapter: requireSurfaceModuleRole(nvrSurfaceApp, SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER, {
+    moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
+    primitiveRef: "stream.intent",
+  }),
+});
+
+const nvrRuntimeAttachContext = Object.freeze({
+  ...nvrSurfaceAttachContext,
+  activeRuntimeClientModuleRef: nvrSurfaceModules.runtimeClient.moduleRef,
+});
 
 type RuntimeZoneScope = {
   zoneId: string;
@@ -1333,7 +1355,7 @@ async function ensureRuntimePort(): Promise<MessagePort | null> {
       debug: diagnosticsEnabled,
       debugInfo: runtimeAttachDebugInfo(window.location.origin),
       logPrefix: "nvr-ui",
-      attachContext: nvrSurfaceAttachContext,
+      attachContext: nvrRuntimeAttachContext,
       onPort: (port) => {
         runtimePort = port as MessagePort;
         runtimeAttached = false;
@@ -2219,6 +2241,7 @@ async function publishRuntimeStreamIntent(sourceIds: string[], timeoutMs = RUNTI
       sourceId,
       sessionId: expectedSessionId,
       nonce,
+      moduleRef: nvrSurfaceModules.platformAdapter.moduleRef,
       iceServers: mediaIceServers,
       onCandidate: (candidate) => {
         if (!streamOpenQueued) return;
@@ -2448,6 +2471,7 @@ function adminProjectionFallback(action: string, payload: Record<string, unknown
 }
 
 const nvrAdminAdapter = createNvrAdminAdapter({
+  moduleRef: nvrSurfaceModules.serviceSurfaceAdapter.moduleRef,
   defaultTimeoutMs: ADMIN_INTENT_TIMEOUT_MS,
   applyCameraDeviceConfigTimeoutMs: CAMERA_APPLY_REQUEST_TIMEOUT_MS,
   publishRuntimeServiceIntent,

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,11 @@ import "./styles.css";
 import { renderActionList, setConnectionStateText } from "constitute-ui";
 import { createKeyValueGrid } from "../../constitute-ui/src/index.js";
 import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
-import { requireSurfaceModuleRole } from "../../constitute-ui/src/surface-app-contract.js";
+import {
+  materializationBudgetLimit,
+  requireSurfaceMaterializationBudget,
+  requireSurfaceModuleRole,
+} from "../../constitute-ui/src/surface-app-contract.js";
 import { renderShell } from "./shell";
 import { nvrSurfaceApp, nvrSurfaceAttachContext } from "./surface-app-contract.js";
 import {
@@ -100,9 +104,33 @@ const nvrSurfaceModules = Object.freeze({
   }),
 });
 
+const nvrSurfaceBudgets = Object.freeze({
+  preview: requireSurfaceMaterializationBudget(nvrSurfaceApp, "nvr-ui.preview", {
+    payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.MEDIA,
+    copyRole: SWARM.MATERIALIZATION_COPY_ROLE.TRANSPORT,
+    transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.NATIVE,
+  }),
+  streamEvents: requireSurfaceMaterializationBudget(nvrSurfaceApp, "nvr-ui.stream-events", {
+    payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.EVIDENCE,
+    copyRole: SWARM.MATERIALIZATION_COPY_ROLE.BUFFER,
+    transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.REFERENCE_ONLY,
+  }),
+});
+
+const NVR_PREVIEW_SOURCE_LIMIT = Math.max(
+  1,
+  materializationBudgetLimit(
+    nvrSurfaceBudgets.preview,
+    "maxActivePreviews",
+    materializationBudgetLimit(nvrSurfaceBudgets.preview, "maxItems", 2),
+  ),
+);
+const NVR_STREAM_EVENT_LIMIT = Math.max(1, materializationBudgetLimit(nvrSurfaceBudgets.streamEvents, "maxItems", 240));
+
 const nvrRuntimeAttachContext = Object.freeze({
   ...nvrSurfaceAttachContext,
   activeRuntimeClientModuleRef: nvrSurfaceModules.runtimeClient.moduleRef,
+  materializationBudgetRefs: Object.freeze(Object.values(nvrSurfaceBudgets).map((budget) => String(budget.budgetId || ""))),
 });
 
 type RuntimeZoneScope = {
@@ -2287,6 +2315,8 @@ async function publishRuntimeStreamIntent(sourceIds: string[], timeoutMs = RUNTI
       },
       candidates: offerCandidates,
       mediaTransportProfile: runtimeMediaTransportContract(mediaTransportProfile),
+      materializationBudgetRef: String(nvrSurfaceBudgets.preview.budgetId || "nvr-ui.preview"),
+      evidenceBudgetRef: String(nvrSurfaceBudgets.streamEvents.budgetId || "nvr-ui.stream-events"),
       iceServers: {
         stun: runtimeMediaIceServerUrls(mediaTransportProfile, "stun:"),
         turn: runtimeMediaIceServerUrls(mediaTransportProfile, "turn:"),
@@ -4647,7 +4677,7 @@ async function connectLiveGrid(context: RuntimeServiceContext): Promise<void> {
 function runtimePreviewSourceIds(context: RuntimeServiceContext): string[] {
   const display = context.display || {};
   const sources = normalizeSourceIds(display.sources);
-  if (sources.length > 0) return sources;
+  if (sources.length > 0) return sources.slice(0, NVR_PREVIEW_SOURCE_LIMIT);
   return cameraCountForContext(context) > 0 ? [NVR_AUTO_PREVIEW_SOURCE_ID] : [];
 }
 
@@ -4733,7 +4763,7 @@ function resetRuntimeStreamRecovery(reason: string): void {
 }
 
 function activeRuntimeStreamSessions(): RuntimeStreamSession[] {
-  return Array.from(new Set(runtimeStreamSessionsBySessionId.values()));
+  return Array.from(new Set(runtimeStreamSessionsBySessionId.values())).slice(-NVR_STREAM_EVENT_LIMIT);
 }
 
 function runtimeStreamSessionPosture(): {

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ import { preparedServiceRegistryServices } from "../../constitute-ui/src/service
 import {
   applyBrowserStreamAnswer,
   applyBrowserStreamCandidate,
+  bindBrowserMediaStream,
   browserStreamAvailable,
   candidateKey,
   collectBrowserMediaFulfillmentEvidence,
@@ -153,6 +154,10 @@ type RuntimeServiceContext = {
   display?: RuntimeServiceDisplay;
   createdAt: number;
   expiresAt: number;
+};
+
+type SwarmEdgeAttachOptions = {
+  force?: boolean;
 };
 
 type RuntimePreparedStage =
@@ -620,12 +625,12 @@ let streamLiveWatchdogTimer = 0;
 let reconnectInFlight: Promise<void> | null = null;
 let reconnectScheduleInFlight = false;
 let routeBaselineNoticeAt = 0;
-let runtimeEdgeAttachRepairTarget = "";
-let runtimeEdgeAttachRepairAttemptedAt = 0;
-let runtimeEdgeAttachRepairBackoffUntil = 0;
-let runtimeEdgeAttachRepairFailureCount = 0;
-let runtimeEdgeAttachRepairInFlight: Promise<boolean> | null = null;
-let runtimeEdgeAttachRepairInFlightTarget = "";
+let swarmEdgeAttachRepairTarget = "";
+let swarmEdgeAttachRepairAttemptedAt = 0;
+let swarmEdgeAttachRepairBackoffUntil = 0;
+let swarmEdgeAttachRepairFailureCount = 0;
+let swarmEdgeAttachRepairInFlight: Promise<boolean> | null = null;
+let swarmEdgeAttachRepairInFlightTarget = "";
 let reconnectAttemptCount = 0;
 let accountBridgeFrame: HTMLIFrameElement | null = null;
 let accountBridgePromise: Promise<void> | null = null;
@@ -1973,7 +1978,10 @@ function baseRuntimeAuthorityPayload(): Record<string, unknown> {
   return runtimeAuthorityPayloadFromContext(runtimeServiceContext || {});
 }
 
-async function ensureRuntimeSwarmEdgeForContext(context: RuntimeServiceContext): Promise<boolean> {
+async function ensureRuntimeSwarmEdgeForContext(
+  context: RuntimeServiceContext,
+  options: SwarmEdgeAttachOptions = {},
+): Promise<boolean> {
   const edgeEndpoint = localGatewayEdgeEndpoint(context.gatewayPk);
   const rawZoneScope = context.zoneScope || localGatewayExtraZoneScope(context.gatewayPk);
   if (!edgeEndpoint || !rawZoneScope?.zoneId) return false;
@@ -1991,23 +1999,24 @@ async function ensureRuntimeSwarmEdgeForContext(context: RuntimeServiceContext):
     String(zoneScope.ttl || ""),
     String(zoneScope.maxHops || ""),
   ].join("|");
-  if (runtimeEdgeAttachRepairInFlight && runtimeEdgeAttachRepairInFlightTarget === target) {
-    return await runtimeEdgeAttachRepairInFlight;
+  if (swarmEdgeAttachRepairInFlight && swarmEdgeAttachRepairInFlightTarget === target) {
+    return await swarmEdgeAttachRepairInFlight;
   }
-  runtimeEdgeAttachRepairInFlightTarget = target;
-  runtimeEdgeAttachRepairInFlight = (async () => {
+  swarmEdgeAttachRepairInFlightTarget = target;
+  swarmEdgeAttachRepairInFlight = (async () => {
     const now = Date.now();
-    if (runtimeEdgeAttachRepairTarget !== target) {
-      runtimeEdgeAttachRepairTarget = target;
-      runtimeEdgeAttachRepairFailureCount = 0;
-      runtimeEdgeAttachRepairBackoffUntil = 0;
-    } else if (
-      runtimeEdgeAttachRepairBackoffUntil > now
-      || now - runtimeEdgeAttachRepairAttemptedAt < RUNTIME_SWARM_EDGE_ATTACH_REPAIR_RETRY_MS
-    ) {
-      return false;
+    const edgeDisconnected = Boolean(runtimeSnapshot?.edge && runtimeSnapshot.edge.connected !== true);
+    if (swarmEdgeAttachRepairTarget !== target) {
+      swarmEdgeAttachRepairTarget = target;
+      swarmEdgeAttachRepairFailureCount = 0;
+      swarmEdgeAttachRepairBackoffUntil = 0;
+    } else {
+      if (swarmEdgeAttachRepairBackoffUntil > now) return false;
+      if (!options.force && !edgeDisconnected && now - swarmEdgeAttachRepairAttemptedAt < RUNTIME_SWARM_EDGE_ATTACH_REPAIR_RETRY_MS) {
+        return false;
+      }
     }
-    runtimeEdgeAttachRepairAttemptedAt = now;
+    swarmEdgeAttachRepairAttemptedAt = now;
     try {
       await runtimeCall("swarm.edge.attach", {
         payload: {
@@ -2015,25 +2024,25 @@ async function ensureRuntimeSwarmEdgeForContext(context: RuntimeServiceContext):
           zoneScope,
         },
       }, RUNTIME_WRITE_TIMEOUT_MS);
-      runtimeEdgeAttachRepairFailureCount = 0;
-      runtimeEdgeAttachRepairBackoffUntil = 0;
+      swarmEdgeAttachRepairFailureCount = 0;
+      swarmEdgeAttachRepairBackoffUntil = 0;
       appendLog(`runtime swarm edge attach requested for ${edgeEndpoint}`);
       return true;
     } catch (error) {
-      runtimeEdgeAttachRepairFailureCount += 1;
-      runtimeEdgeAttachRepairBackoffUntil = Date.now() + Math.min(
+      swarmEdgeAttachRepairFailureCount += 1;
+      swarmEdgeAttachRepairBackoffUntil = Date.now() + Math.min(
         RUNTIME_SWARM_EDGE_ATTACH_REPAIR_MAX_BACKOFF_MS,
-        RUNTIME_SWARM_EDGE_ATTACH_REPAIR_RETRY_MS * runtimeEdgeAttachRepairFailureCount,
+        RUNTIME_SWARM_EDGE_ATTACH_REPAIR_RETRY_MS * swarmEdgeAttachRepairFailureCount,
       );
       throw error;
     }
   })();
   try {
-    return await runtimeEdgeAttachRepairInFlight;
+    return await swarmEdgeAttachRepairInFlight;
   } finally {
-    if (runtimeEdgeAttachRepairInFlightTarget === target) {
-      runtimeEdgeAttachRepairInFlight = null;
-      runtimeEdgeAttachRepairInFlightTarget = "";
+    if (swarmEdgeAttachRepairInFlightTarget === target) {
+      swarmEdgeAttachRepairInFlight = null;
+      swarmEdgeAttachRepairInFlightTarget = "";
     }
   }
 }
@@ -2171,9 +2180,7 @@ function startRuntimeStreamStatsMonitor(session: RuntimeStreamSession, video?: H
 
 function bindRuntimeStreamTrack(sourceId: string, stream: unknown, track: MediaStreamTrack, session: RuntimeStreamSession): void {
   const tile = ensureCameraTile(sourceId);
-  tile.video.srcObject = stream as MediaStream;
-  reportMediaFulfillmentEvidence(mediaFulfillmentEvidenceFromTrack(session, track));
-  startRuntimeStreamStatsMonitor(session, tile.video);
+  const mediaStream = stream as MediaStream;
   const markRenderLive = (evidence = reportRenderReadiness(session, tile.video)) => {
     if (evidence.state !== SWARM.MEDIA_FULFILLMENT_STATE.USABLE) {
       const readiness = mediaEvidenceReadinessState(evidence) || "waitingRender";
@@ -2202,10 +2209,24 @@ function bindRuntimeStreamTrack(sourceId: string, stream: unknown, track: MediaS
   tile.video.addEventListener("loadedmetadata", markPendingRender, { once: true });
   tile.video.addEventListener("resize", markPendingRender);
   tile.video.addEventListener("playing", markRenderLive, { once: true });
-  if (track.readyState === "live") {
-    markPendingRender();
-    window.setTimeout(markRenderLive, 1_000);
-  }
+  reportMediaFulfillmentEvidence(mediaFulfillmentEvidenceFromTrack(session, track));
+  startRuntimeStreamStatsMonitor(session, tile.video);
+  void bindBrowserMediaStream(tile.video, mediaStream).then((result) => {
+    if (!result.ok) {
+      const detail = result.reason || "browser media playback request failed";
+      appendLog(`stream render bind failed: ${detail}`);
+      setTileState(sourceId, "connecting", "Waiting for browser media playback.");
+      setDrawerStatus(`Live media track attached; browser playback is pending (${detail}).`);
+      scheduleStreamLiveWatchdog("stream render bind failed");
+    }
+    if (track.readyState === "live") {
+      markPendingRender();
+      window.setTimeout(markRenderLive, 1_000);
+    }
+  }).catch((error) => {
+    appendLog(`stream render bind failed: ${String((error as Error)?.message || error)}`);
+    scheduleStreamLiveWatchdog("stream render bind failed");
+  });
 }
 
 function handleRuntimeStreamAdapterState(session: RuntimeStreamSession, state: BrowserStreamAdapterState): void {
@@ -4931,7 +4952,7 @@ function scheduleAutomaticReconnect(reason: string): void {
         reconnectInFlight = (async () => {
           let retryReason = "";
           try {
-            await reconnect();
+            await reconnect({ force: true });
           } catch (error) {
             const detail = String((error as Error)?.message || error || "automatic reconnect failed");
             appendLog(`automatic reconnect failed: ${detail}`);
@@ -4982,13 +5003,13 @@ function scheduleRuntimeAuthorityReconnect(reason: string): void {
   }, delayMs);
 }
 
-async function reconnect(): Promise<void> {
+async function reconnect(options: SwarmEdgeAttachOptions = {}): Promise<void> {
   cancelScheduledReconnect();
   if (!runtimeServiceContext) {
     runtimeServiceContext = await loadRuntimeServiceContext();
   }
   refreshSummary(runtimeServiceContext);
-  await ensureRuntimeSwarmEdgeForContext(runtimeServiceContext).catch((error) => {
+  await ensureRuntimeSwarmEdgeForContext(runtimeServiceContext, options).catch((error) => {
     appendLog(`runtime swarm edge attach unavailable: ${String((error as Error)?.message || error)}`);
   });
   await connectLiveGrid(runtimeServiceContext);

--- a/src/main.ts
+++ b/src/main.ts
@@ -570,6 +570,7 @@ let runtimeClient: ReturnType<typeof createRuntimeSurfaceClient> | null = null;
 let runtimePort: MessagePort | null = null;
 let runtimeAttached = false;
 let runtimeDiagnosticsAgent: ReturnType<typeof attachRuntimeDiagnostics> | null = null;
+let runtimeSnapshotConsumerFloor: Record<string, unknown> | null = null;
 let runtimeServiceContext: RuntimeServiceContext | null = null;
 let directEntryRepairTimer = 0;
 let directEntryRepairInFlight: Promise<void> | null = null;
@@ -1403,6 +1404,9 @@ async function ensureRuntimePort(): Promise<MessagePort | null> {
         runtimeAttached = Boolean(runtimePort);
         absorbRuntimeSnapshot(snapshot);
         refreshRuntimeProjectionLabels();
+      },
+      onConsumerFloor: (floor) => {
+        runtimeSnapshotConsumerFloor = (floor && typeof floor === "object") ? floor as Record<string, unknown> : null;
       },
       onAttachTimeout: () => {
         runtimeAttached = false;
@@ -3953,17 +3957,28 @@ function renderTileStreamStatus(sourceId: string): void {
 
 function renderProjectionSyncSummary(): string {
   const records = Object.entries(nvrProjectionState.projectionRecords);
-  if (records.length === 0) return "";
+  const rows = records.map(([channelId, record]) => {
+    const freshness = record.freshness && typeof record.freshness === "object" ? record.freshness : {};
+    const state = String(freshness.state || "fresh").trim() || "fresh";
+    const revision = String(record.revision || "").trim();
+    const updated = compactTimestamp(freshness.updatedAt || record.retainedAt || record.updatedAt);
+    return [channelId, [state, revision ? `rev ${revision}` : "", updated].filter(Boolean).join(" / ")];
+  });
+  if (runtimeSnapshotConsumerFloor) {
+    rows.push([
+      "runtime.floor",
+      [
+        String(runtimeSnapshotConsumerFloor.lagState || "unknown").trim() || "unknown",
+        runtimeSnapshotConsumerFloor.ackFloor ? `ack ${runtimeSnapshotConsumerFloor.ackFloor}` : "",
+        runtimeSnapshotConsumerFloor.witnessFloor ? `witness ${runtimeSnapshotConsumerFloor.witnessFloor}` : "",
+      ].filter(Boolean).join(" / "),
+    ]);
+  }
+  if (rows.length === 0) return "";
   return `
     <section class="nestedPanel runtimeProjectionPanel">
       <div class="summaryLabel">Runtime Projection</div>
-      ${renderKeyValueGridMarkup(records.map(([channelId, record]) => {
-        const freshness = record.freshness && typeof record.freshness === "object" ? record.freshness : {};
-        const state = String(freshness.state || "fresh").trim() || "fresh";
-        const revision = String(record.revision || "").trim();
-        const updated = compactTimestamp(freshness.updatedAt || record.retainedAt || record.updatedAt);
-        return [channelId, [state, revision ? `rev ${revision}` : "", updated].filter(Boolean).join(" / ")];
-      }))}
+      ${renderKeyValueGridMarkup(rows)}
     </section>
   `;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4002,6 +4002,23 @@ function renderStoragePinIntentSummary(): string {
   `;
 }
 
+function renderRuntimePostureSummary(): string {
+  const shellState = deriveRuntimeShellState(runtimeSnapshot, { context: shellDeriveContext(), adapterLive: hasLiveTiles() });
+  const resource = shellState.resource || {};
+  const retention = shellState.retention || {};
+  return `
+    <section class="nestedPanel runtimePosturePanel">
+      <div class="summaryLabel">Runtime Posture</div>
+      ${renderKeyValueGridMarkup([
+        ["Resource", String(resource.state || "unknown")],
+        ["Cleanup", resource.cleanupAllowed ? "allowed" : String(resource.cleanupReason || "blocked")],
+        ["Retention", String(retention.state || "unknown")],
+        ["Release", retention.releaseRequired ? String(retention.reason || "blocked") : "ready"],
+      ])}
+    </section>
+  `;
+}
+
 function renderHistoryProjectionStatus(): void {
   const pinSummary = renderStoragePinIntentSummary();
   const statusSummary = renderProjectionSyncSummary();
@@ -4074,6 +4091,7 @@ function renderNvrSettingsSummary(): void {
   const accessSummary = nvrAccessSummary();
   const projectionSummary = renderProjectionSyncSummary();
   const storageSummary = renderStoragePinIntentSummary();
+  const runtimePostureSummary = renderRuntimePostureSummary();
   nvrSettingsSummaryEl.innerHTML = `
     <section class="nestedPanel">
       <div class="summaryLabel">Service</div>
@@ -4097,6 +4115,7 @@ function renderNvrSettingsSummary(): void {
     </section>
     ${projectionSummary}
     ${storageSummary}
+    ${runtimePostureSummary}
     ${
       viewerIsOwner()
         ? `<section class="nestedPanel">

--- a/src/nvr-admin-adapter.ts
+++ b/src/nvr-admin-adapter.ts
@@ -2,6 +2,7 @@ export type NvrAdminAdapterPayload = Record<string, unknown>;
 export type NvrAdminAdapterResult = Record<string, unknown>;
 
 export type NvrAdminAdapterOptions = {
+  moduleRef?: string;
   defaultTimeoutMs: number;
   applyCameraDeviceConfigTimeoutMs: number;
   publishRuntimeServiceIntent: (
@@ -16,6 +17,7 @@ export type NvrAdminAdapterOptions = {
 };
 
 export type NvrAdminAdapter = {
+  moduleRef: string;
   timeoutMs(action: string): number;
   request(action: string, payload?: NvrAdminAdapterPayload): Promise<NvrAdminAdapterResult>;
 };
@@ -43,6 +45,7 @@ export function nvrAdminActionTimeoutMs(
 
 export function createNvrAdminAdapter(options: NvrAdminAdapterOptions): NvrAdminAdapter {
   return {
+    moduleRef: String(options.moduleRef || ""),
     timeoutMs(action: string): number {
       return nvrAdminActionTimeoutMs(action, options);
     },

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,4 +1,4 @@
-import { SURFACE_APP, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
+import { SURFACE_APP, SWARM, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
 import { defineSurfaceAppContract } from "../../constitute-ui/src/surface-app-contract.js";
 
 const ISSUED_AT = 1700000000;
@@ -87,8 +87,44 @@ export const nvrSurfaceAppContract = assertSurfaceAppContract({
     { projectionId: "nvr.streams", channelId: "nvr.streams" },
   ],
   materializationBudgets: [
-    { budgetId: "nvr-ui.preview", maxItems: 2 },
-    { budgetId: "nvr-ui.stream-events", maxItems: 240 },
+    {
+      kind: SWARM.RECORD_KIND.MATERIALIZATION_BUDGET,
+      budgetId: "nvr-ui.preview",
+      sourceAuthority: "runtime.media.transport.path",
+      consumerRef: "nvr-ui.preview",
+      payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.MEDIA,
+      copyRole: SWARM.MATERIALIZATION_COPY_ROLE.TRANSPORT,
+      transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.NATIVE,
+      privacyTier: SWARM.MATERIALIZATION_PRIVACY_TIER.UI_PROJECTION,
+      state: SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET,
+      limits: { maxItems: 2, maxActivePreviews: 2 },
+      snapshotPolicy: { mode: "none" },
+      deltaPolicy: { mode: "media-evidence" },
+      coalescing: { key: "sourceId" },
+      cardinality: { maxSourceIds: 2 },
+      schema: { state: SWARM.MATERIALIZATION_SCHEMA_STATE.CURRENT, version: "nvr-ui.preview.v1" },
+      issuedAt: ISSUED_AT,
+    },
+    {
+      kind: SWARM.RECORD_KIND.MATERIALIZATION_BUDGET,
+      budgetId: "nvr-ui.stream-events",
+      sourceAuthority: "runtime.media.fulfillment",
+      consumerRef: "nvr-ui.stream-events",
+      payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.EVIDENCE,
+      copyRole: SWARM.MATERIALIZATION_COPY_ROLE.BUFFER,
+      transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.REFERENCE_ONLY,
+      privacyTier: SWARM.MATERIALIZATION_PRIVACY_TIER.SAFE_FACTS,
+      state: SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET,
+      limits: { maxItems: 240 },
+      snapshotPolicy: { mode: "bounded-session-buffer" },
+      deltaPolicy: { mode: "coalesced-by-session" },
+      coalescing: { key: "sessionId" },
+      cardinality: { maxSessionRefs: 240 },
+      schema: { state: SWARM.MATERIALIZATION_SCHEMA_STATE.CURRENT, version: "nvr-ui.stream-events.v1" },
+      referenceRefs: ["runtime.media.fulfillment"],
+      retentionClass: "ephemeral.ui-evidence",
+      issuedAt: ISSUED_AT,
+    },
   ],
   updatePosture: {
     state: SURFACE_APP.UPDATE_POSTURE.STATIC,

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -69,6 +69,7 @@ test("nvr ui activates runtime stream intents without owning browser transport s
   assert.match(adapter, /export function runtimeMediaTransportContract/);
   assert.match(adapter, /export function runtimeMediaTransportBlockedDetail/);
   assert.match(adapter, /export function isRuntimeMediaTransportProfileFailure/);
+  assert.match(main, /moduleRef: nvrSurfaceModules\.platformAdapter\.moduleRef/);
   assert.doesNotMatch(main, /function runtimeMediaIceServers/);
   assert.doesNotMatch(main, /function runtimeMediaIceServerUrls/);
   assert.doesNotMatch(main, /function runtimeMediaTransportContract/);
@@ -111,9 +112,12 @@ test("nvr ui attaches to the account-owned runtime worker contract", () => {
   const main = source("constitute-nvr-ui/src/main.ts");
 
   assert.match(main, /createRuntimeSurfaceClient/);
+  assert.match(main, /requireSurfaceModuleRole/);
   assert.match(main, /from "\.\.\/\.\.\/constitute-ui\/src\/runtime-surface-client\.js"/);
   assert.match(main, /from "\.\/surface-app-contract\.js"/);
-  assert.match(main, /attachContext: nvrSurfaceAttachContext/);
+  assert.match(main, /nvrSurfaceModules/);
+  assert.match(main, /activeRuntimeClientModuleRef/);
+  assert.match(main, /attachContext: nvrRuntimeAttachContext/);
   assert.match(main, /from "\.\.\/\.\.\/constitute-account\/runtime-contract\.js"/);
   assert.match(main, /PLATFORM_RUNTIME_BUILD_ID as RUNTIME_WORKER_BUILD_ID/);
   assert.match(main, /RUNTIME_STREAM_OPEN/);
@@ -163,6 +167,8 @@ test("nvr service administration uses a service-surface adapter boundary", () =>
   assert.match(adminAdapter, /export function createNvrAdminAdapter/);
   assert.match(adminAdapter, /export function normalizeNvrAdminAdapterError/);
   assert.match(adminAdapter, /export function nvrAdminActionTimeoutMs/);
+  assert.match(adminAdapter, /moduleRef: String\(options\.moduleRef \|\| ""\)/);
+  assert.match(main, /moduleRef: nvrSurfaceModules\.serviceSurfaceAdapter\.moduleRef/);
   assert.match(adminAdapter, /action === "apply_camera_device_config"/);
   assert.match(adminAdapter, /Gateway update required before camera administration is available/);
   assert.match(adminAdapter, /Owner runtime access is required before camera administration is available/);

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -62,6 +62,10 @@ test("nvr ui activates runtime stream intents without owning browser transport s
   assert.match(adapter, /mediaFulfillmentEvidenceFromAdapterState/);
   assert.match(adapter, /mediaFulfillmentEvidenceFromRender/);
   assert.match(adapter, /collectBrowserMediaFulfillmentEvidence/);
+  assert.match(adapter, /bindBrowserMediaStream/);
+  assert.match(nvrAdapter, /bindBrowserMediaStream/);
+  assert.match(main, /bindBrowserMediaStream\(tile\.video, mediaStream\)/);
+  assert.match(main, /reconnect\(\{ force: true \}\)/);
   assert.match(adapter, /inboundRtpStalled/);
   assert.match(adapter, /export type RuntimeMediaTransportProfile/);
   assert.match(adapter, /export function runtimeMediaIceServers/);
@@ -81,6 +85,7 @@ test("nvr ui activates runtime stream intents without owning browser transport s
   assert.match(main, /runtimeStreamRecoveryPosture/);
   assert.match(main, /resetRuntimeStreamRecovery/);
   assert.match(main, /runtimeStreamRecoveryParentIntentId/);
+  assert.doesNotMatch(main, /tile\.video\.srcObject = stream/);
   assert.match(main, /applyRuntimeRouteObservationToStreamSession/);
   assert.match(streamSession, /memberWritten/);
   assert.match(streamSession, /memberRead/);

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -245,6 +245,7 @@ test("nvr ui uses shared summary row component instead of a local kv dialect", (
 test("first-party account centers use shared shell state and account-only actions", () => {
   const account = source("constitute-account/app.js");
   const gateway = source("constitute-gateway-ui/src/main.js");
+  const gatewayRuntimeModel = source("constitute-gateway-ui/src/runtime-model.js");
   const logging = source("constitute-logging-ui/src/main.js");
   const nvr = source("constitute-nvr-ui/src/main.ts");
   const all = [account, gateway, logging, nvr].join("\n");
@@ -253,6 +254,10 @@ test("first-party account centers use shared shell state and account-only action
   assert.match(gateway, /deriveRuntimeShellState/);
   assert.match(logging, /deriveRuntimeShellState/);
   assert.match(nvr, /deriveRuntimeShellState/);
+  assert.match(account, /runtimeResourceStatus/);
+  assert.match(gatewayRuntimeModel, /Resource posture/);
+  assert.match(logging, /shellState\.resource\?\.state/);
+  assert.match(nvr, /Runtime Posture/);
   assert.doesNotMatch(all, /Copy Identity ID/);
   assert.doesNotMatch(all, /account\.copy_identity/);
 


### PR DESCRIPTION
## Summary
- Consumes the shared browser media binding helper from the surface adapter plane.
- Keeps stream recovery from reusing stale edge posture when reconnecting after media failure.
- Guards NVR UI against direct media-element stream ownership in source tests.

## Proof
- npm run test:source
- npm run build
- root check:all from the convergence train
- NVR 30s and 180s lab stream proof with moving video