### PR TITLE
Adopt surface module registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -885,7 +885,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#166d55d1c05f2b4ef4db898f6fa74c036489fa54"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#007318f482c1259e67c49e1cc40bc2dee3604b3a"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,7 +885,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0af1d29f85c225b567d2ced4f2487b29efc41a9d"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0c739a1b4200214487c40e69fb12d7de19f95633"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -885,7 +885,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0c739a1b4200214487c40e69fb12d7de19f95633"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#166d55d1c05f2b4ef4db898f6fa74c036489fa54"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "@noble/ciphers": "^1.2.1",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0",
-        "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
+        "constitute-protocol": "github:Aux0x7F/constitute-protocol#main",
+        "constitute-ui": "github:Aux0x7F/constitute-ui#main"
       },
       "devDependencies": {
         "@playwright/test": "^1.54.2",
@@ -876,7 +876,7 @@
     },
     "node_modules/constitute-protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#ab3f739ffcf53c1e1e594e36bbe458b5233ef822",
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#3a452b5f9482f28ebd07f17549cba15b6355d530",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.1",
@@ -885,7 +885,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#007318f482c1259e67c49e1cc40bc2dee3604b3a"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#3a677aa320282325b8def8be82473279bd70e0b8"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0",
         "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/swarm-runtime-convergence-ui"
+        "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
       },
       "devDependencies": {
         "@playwright/test": "^1.54.2",
@@ -885,7 +885,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#ead823d8d8271cfaf19c021c7a675c224d9d4912"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#0af1d29f85c225b567d2ced4f2487b29efc41a9d"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "@noble/ciphers": "^1.2.1",
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.8.0",
-    "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
+    "constitute-protocol": "github:Aux0x7F/constitute-protocol#main",
+    "constitute-ui": "github:Aux0x7F/constitute-ui#main"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
@@ -23,5 +23,3 @@
     "vite": "^6.2.0"
   }
 }
-
-

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@noble/curves": "^1.9.7",
     "@noble/hashes": "^1.8.0",
     "constitute-protocol": "github:Aux0x7F/constitute-protocol#codex/swarm-runtime-convergence-protocol",
-    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/swarm-runtime-convergence-ui"
+    "constitute-ui": "github:Aux0x7F/constitute-ui#codex/surface-sdk-boundary-20260517"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ import {
   runtimeWorkerScriptUrl as accountRuntimeWorkerScriptUrl,
 } from "../../constitute-account/runtime-contract.js";
 import { RUNTIME_DIAGNOSTIC_OPERATOR_PLANES, attachRuntimeDiagnostics } from "../../constitute-account/runtime-diagnostics.js";
-import { browserStorageShellContext, deriveRuntimeShellState } from "../../constitute-account/runtime-shell-state.js";
+import { browserStorageShellContext, deriveRuntimeShellState } from "../../constitute-ui/src/runtime-shell-state.js";
 import {
   applyRuntimeActivationPostureToStreamSession,
   applyRuntimeMediaFulfillmentPostureToStreamSession,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,8 +6,11 @@ import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surf
 import {
   materializationBudgetLimit,
   requireSurfaceMaterializationBudget,
-  requireSurfaceModuleRole,
 } from "../../constitute-ui/src/surface-app-contract.js";
+import {
+  createSurfaceModuleRegistry,
+  surfaceModuleRegistryPosture,
+} from "../../constitute-ui/src/surface-module-registry.js";
 import { renderShell } from "./shell";
 import { nvrSurfaceApp, nvrSurfaceAttachContext } from "./surface-app-contract.js";
 import {
@@ -90,16 +93,69 @@ import {
   type MediaTransportObservation,
 } from "../../constitute-protocol/src/index.js";
 
+const nvrSurfaceModuleRegistry = createSurfaceModuleRegistry([
+  {
+    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    version: "0.1.0",
+    implementation: { createRuntimeSurfaceClient },
+  },
+  {
+    moduleRef: "constitute-nvr-ui/nvr-projection-model@0.2.0",
+    role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    version: "0.2.0",
+    implementation: {
+      cameraCountForContext,
+      humanizeSourceId,
+      normalizeRuntimeCameraEntries,
+      normalizeSourceIds,
+      nvrDisplayFromRecord,
+    },
+  },
+  {
+    moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+    version: "0.1.0",
+    implementation: {
+      bindBrowserMediaStream,
+      browserStreamAvailable,
+      collectBrowserMediaFulfillmentEvidence,
+      createBrowserStreamOffer,
+      runtimeMediaTransportContract,
+    },
+  },
+  {
+    moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
+    role: SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER,
+    version: "0.2.0",
+    implementation: { createNvrAdminAdapter, normalizeNvrAdminAdapterError },
+  },
+  {
+    moduleRef: "constitute-nvr-ui/product-view@0.2.0",
+    role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+    version: "0.2.0",
+    implementation: { renderShell },
+  },
+]);
+
+function requireNvrSurfaceModuleClaim(role: string, options: { moduleRef: string; primitiveRef?: string }) {
+  const posture = surfaceModuleRegistryPosture(nvrSurfaceModuleRegistry, nvrSurfaceApp, role, options);
+  if (posture.state !== "ready" || !posture.claim) {
+    throw new Error(`NVR surface module unavailable: ${posture.blockedReason} ${role} ${options.moduleRef}`.trim());
+  }
+  return posture.claim;
+}
+
 const nvrSurfaceModules = Object.freeze({
-  runtimeClient: requireSurfaceModuleRole(nvrSurfaceApp, SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT, {
+  runtimeClient: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT, {
     moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
     primitiveRef: "runtime.attach",
   }),
-  platformAdapter: requireSurfaceModuleRole(nvrSurfaceApp, SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER, {
+  platformAdapter: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER, {
     moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
     primitiveRef: "media.transport.path",
   }),
-  serviceSurfaceAdapter: requireSurfaceModuleRole(nvrSurfaceApp, SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER, {
+  serviceSurfaceAdapter: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER, {
     moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
     primitiveRef: "stream.intent",
   }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,17 +2,18 @@ import "constitute-ui/styles.css";
 import "./styles.css";
 import { renderActionList, setConnectionStateText } from "constitute-ui";
 import { createKeyValueGrid } from "../../constitute-ui/src/index.js";
-import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
-import {
-  materializationBudgetLimit,
-  requireSurfaceMaterializationBudget,
-} from "../../constitute-ui/src/surface-app-contract.js";
-import {
-  createSurfaceModuleRegistry,
-  surfaceModuleRegistryPosture,
-} from "../../constitute-ui/src/surface-module-registry.js";
-import { renderShell } from "./shell";
 import { nvrSurfaceApp, nvrSurfaceAttachContext } from "./surface-app-contract.js";
+import {
+  NVR_PREVIEW_SOURCE_LIMIT,
+  NVR_STREAM_EVENT_LIMIT,
+  nvrPlatformAdapterModule,
+  nvrProductViewModule,
+  nvrProjectionModelModule,
+  nvrRuntimeClientModule,
+  nvrServiceSurfaceAdapterModule,
+  nvrSurfaceBudgets,
+  nvrSurfaceModules,
+} from "./surface-modules";
 import {
   PLATFORM_RUNTIME_BUILD_ID as RUNTIME_WORKER_BUILD_ID,
   RUNTIME_AUTHORITY_POSTURE_GET,
@@ -48,6 +49,27 @@ import {
 } from "../../constitute-ui/src/runtime-stream-session.js";
 import { preparedServiceRegistryServices } from "../../constitute-ui/src/service-registry-model.js";
 import {
+  MEDIA_RENDER_BLOCKED_GRACE_MS,
+  MEDIA_RENDER_WAITING_GRACE_MS,
+  type BrowserStreamAdapterState,
+  type BrowserStreamSession,
+  type RuntimeMediaTransportProfile,
+} from "./browser-stream-adapter";
+import {
+  NVR_AUTO_PREVIEW_SOURCE_ID,
+  type GrantedScope,
+  type RuntimeCameraAccessDisplay,
+  type RuntimeServiceDisplay,
+} from "./nvr-projection-model";
+import {
+  STREAM_SESSION_LIFECYCLE_PHASE,
+  SWARM,
+  streamSessionLifecycleRecordFromCarrier,
+  type MediaFulfillmentEvidence,
+  type MediaTransportObservation,
+} from "../../constitute-protocol/src/index.js";
+
+const {
   applyBrowserStreamAnswer,
   applyBrowserStreamCandidate,
   bindBrowserMediaStream,
@@ -57,8 +79,6 @@ import {
   closeBrowserStreamSession,
   createBrowserStreamOffer,
   isRuntimeMediaTransportProfileFailure,
-  MEDIA_RENDER_BLOCKED_GRACE_MS,
-  MEDIA_RENDER_WAITING_GRACE_MS,
   mediaFulfillmentEvidenceFromAdapterState,
   mediaFulfillmentEvidenceFromRender,
   mediaFulfillmentEvidenceFromTrack,
@@ -68,121 +88,18 @@ import {
   runtimeMediaIceServers,
   runtimeMediaTransportBlockedDetail,
   runtimeMediaTransportContract,
-  type BrowserStreamAdapterState,
-  type BrowserStreamSession,
-  type RuntimeMediaTransportProfile,
-} from "./browser-stream-adapter";
-import { createNvrAdminAdapter, normalizeNvrAdminAdapterError } from "./nvr-admin-adapter";
-import {
-  NVR_AUTO_PREVIEW_SOURCE_ID,
+} = nvrPlatformAdapterModule;
+
+const {
   cameraCountForContext,
   humanizeSourceId,
   normalizeRuntimeCameraEntries,
   normalizeSourceIds,
   nvrDisplayFromRecord,
-  type GrantedScope,
-  type RuntimeCameraAccessDisplay,
-  type RuntimeServiceDisplay,
-} from "./nvr-projection-model";
-import {
-  SURFACE_APP,
-  STREAM_SESSION_LIFECYCLE_PHASE,
-  SWARM,
-  streamSessionLifecycleRecordFromCarrier,
-  type MediaFulfillmentEvidence,
-  type MediaTransportObservation,
-} from "../../constitute-protocol/src/index.js";
+} = nvrProjectionModelModule;
 
-const nvrSurfaceModuleRegistry = createSurfaceModuleRegistry([
-  {
-    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
-    role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
-    version: "0.1.0",
-    implementation: { createRuntimeSurfaceClient },
-  },
-  {
-    moduleRef: "constitute-nvr-ui/nvr-projection-model@0.2.0",
-    role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
-    version: "0.2.0",
-    implementation: {
-      cameraCountForContext,
-      humanizeSourceId,
-      normalizeRuntimeCameraEntries,
-      normalizeSourceIds,
-      nvrDisplayFromRecord,
-    },
-  },
-  {
-    moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
-    role: SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
-    version: "0.1.0",
-    implementation: {
-      bindBrowserMediaStream,
-      browserStreamAvailable,
-      collectBrowserMediaFulfillmentEvidence,
-      createBrowserStreamOffer,
-      runtimeMediaTransportContract,
-    },
-  },
-  {
-    moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
-    role: SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER,
-    version: "0.2.0",
-    implementation: { createNvrAdminAdapter, normalizeNvrAdminAdapterError },
-  },
-  {
-    moduleRef: "constitute-nvr-ui/product-view@0.2.0",
-    role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
-    version: "0.2.0",
-    implementation: { renderShell },
-  },
-]);
-
-function requireNvrSurfaceModuleClaim(role: string, options: { moduleRef: string; primitiveRef?: string }) {
-  const posture = surfaceModuleRegistryPosture(nvrSurfaceModuleRegistry, nvrSurfaceApp, role, options);
-  if (posture.state !== "ready" || !posture.claim) {
-    throw new Error(`NVR surface module unavailable: ${posture.blockedReason} ${role} ${options.moduleRef}`.trim());
-  }
-  return posture.claim;
-}
-
-const nvrSurfaceModules = Object.freeze({
-  runtimeClient: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT, {
-    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
-    primitiveRef: "runtime.attach",
-  }),
-  platformAdapter: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER, {
-    moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
-    primitiveRef: "media.transport.path",
-  }),
-  serviceSurfaceAdapter: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER, {
-    moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
-    primitiveRef: "stream.intent",
-  }),
-});
-
-const nvrSurfaceBudgets = Object.freeze({
-  preview: requireSurfaceMaterializationBudget(nvrSurfaceApp, "nvr-ui.preview", {
-    payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.MEDIA,
-    copyRole: SWARM.MATERIALIZATION_COPY_ROLE.TRANSPORT,
-    transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.NATIVE,
-  }),
-  streamEvents: requireSurfaceMaterializationBudget(nvrSurfaceApp, "nvr-ui.stream-events", {
-    payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.EVIDENCE,
-    copyRole: SWARM.MATERIALIZATION_COPY_ROLE.BUFFER,
-    transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.REFERENCE_ONLY,
-  }),
-});
-
-const NVR_PREVIEW_SOURCE_LIMIT = Math.max(
-  1,
-  materializationBudgetLimit(
-    nvrSurfaceBudgets.preview,
-    "maxActivePreviews",
-    materializationBudgetLimit(nvrSurfaceBudgets.preview, "maxItems", 2),
-  ),
-);
-const NVR_STREAM_EVENT_LIMIT = Math.max(1, materializationBudgetLimit(nvrSurfaceBudgets.streamEvents, "maxItems", 240));
+const { createNvrAdminAdapter, normalizeNvrAdminAdapterError } = nvrServiceSurfaceAdapterModule;
+const { renderShell } = nvrProductViewModule;
 
 const nvrRuntimeAttachContext = Object.freeze({
   ...nvrSurfaceAttachContext,
@@ -627,7 +544,7 @@ const cameraTiles = new Map<string, CameraTile>();
 const runtimeCameraInfoBySourceId = new Map<string, RuntimeCameraAccessDisplay>();
 const notifications: NotificationEntry[] = [];
 
-let runtimeClient: ReturnType<typeof createRuntimeSurfaceClient> | null = null;
+let runtimeClient: ReturnType<typeof nvrRuntimeClientModule.createRuntimeSurfaceClient> | null = null;
 let runtimePort: MessagePort | null = null;
 let runtimeAttached = false;
 let runtimeDiagnosticsAgent: ReturnType<typeof attachRuntimeDiagnostics> | null = null;
@@ -1435,7 +1352,7 @@ async function ensureRuntimePort(): Promise<MessagePort | null> {
   if (runtimeClient?.attached && runtimeClient.port) return runtimeClient.port as MessagePort;
   if (typeof SharedWorker === "undefined") return null;
   if (!runtimeClient) {
-    runtimeClient = createRuntimeSurfaceClient({
+    runtimeClient = nvrRuntimeClientModule.createRuntimeSurfaceClient({
       clientId: randomOpaqueId("runtime-nvr"),
       surface: "constitute-nvr-ui",
       workerUrl: runtimeWorkerUrl(),

--- a/src/surface-modules.ts
+++ b/src/surface-modules.ts
@@ -105,24 +105,38 @@ export function requireNvrSurfaceModuleClaim(role: string, options: { moduleRef:
   return posture.claim;
 }
 
+export function requireNvrSurfaceModuleBinding(role: string, options: { moduleRef: string; primitiveRef?: string }) {
+  const posture = surfaceModuleRegistryPosture(nvrSurfaceModuleRegistry, nvrSurfaceApp, role, options);
+  const implementation = posture.implementation?.implementation;
+  if (posture.state !== "ready" || !posture.claim || !implementation) {
+    throw new Error(`NVR surface module implementation unavailable: ${posture.blockedReason} ${role} ${options.moduleRef}`.trim());
+  }
+  return Object.freeze({
+    ...posture.claim,
+    implementationRef: posture.implementationRef,
+    fallbackTried: posture.fallbackTried,
+    implementation,
+  });
+}
+
 export const nvrSurfaceModules = Object.freeze({
-  runtimeClient: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT, {
+  runtimeClient: requireNvrSurfaceModuleBinding(SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT, {
     moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
     primitiveRef: "runtime.attach",
   }),
-  projectionModel: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL, {
+  projectionModel: requireNvrSurfaceModuleBinding(SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL, {
     moduleRef: "constitute-nvr-ui/nvr-projection-model@0.2.0",
     primitiveRef: "projection.materialization",
   }),
-  platformAdapter: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER, {
+  platformAdapter: requireNvrSurfaceModuleBinding(SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER, {
     moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
     primitiveRef: "media.transport.path",
   }),
-  serviceSurfaceAdapter: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER, {
+  serviceSurfaceAdapter: requireNvrSurfaceModuleBinding(SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER, {
     moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
     primitiveRef: "stream.intent",
   }),
-  productView: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW, {
+  productView: requireNvrSurfaceModuleBinding(SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW, {
     moduleRef: "constitute-nvr-ui/product-view@0.2.0",
     primitiveRef: "runtime.posture.render",
   }),

--- a/src/surface-modules.ts
+++ b/src/surface-modules.ts
@@ -1,0 +1,162 @@
+import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
+import {
+  materializationBudgetLimit,
+  requireSurfaceMaterializationBudget,
+} from "../../constitute-ui/src/surface-app-contract.js";
+import {
+  createSurfaceModuleRegistry,
+  surfaceModuleRegistryPosture,
+} from "../../constitute-ui/src/surface-module-registry.js";
+import { SURFACE_APP, SWARM } from "../../constitute-protocol/src/index.js";
+import { renderShell } from "./shell";
+import { nvrSurfaceApp } from "./surface-app-contract.js";
+import {
+  applyBrowserStreamAnswer,
+  applyBrowserStreamCandidate,
+  bindBrowserMediaStream,
+  browserStreamAvailable,
+  candidateKey,
+  collectBrowserMediaFulfillmentEvidence,
+  closeBrowserStreamSession,
+  createBrowserStreamOffer,
+  isRuntimeMediaTransportProfileFailure,
+  mediaFulfillmentEvidenceFromAdapterState,
+  mediaFulfillmentEvidenceFromRender,
+  mediaFulfillmentEvidenceFromTrack,
+  mediaFulfillmentReleaseEvidence,
+  mediaTransportObservationFromFulfillmentEvidence,
+  runtimeMediaIceServerUrls,
+  runtimeMediaIceServers,
+  runtimeMediaTransportBlockedDetail,
+  runtimeMediaTransportContract,
+} from "./browser-stream-adapter";
+import { createNvrAdminAdapter, normalizeNvrAdminAdapterError } from "./nvr-admin-adapter";
+import {
+  cameraCountForContext,
+  humanizeSourceId,
+  normalizeRuntimeCameraEntries,
+  normalizeSourceIds,
+  nvrDisplayFromRecord,
+} from "./nvr-projection-model";
+
+export const nvrSurfaceModuleRegistry = createSurfaceModuleRegistry([
+  {
+    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    version: "0.1.0",
+    implementation: { createRuntimeSurfaceClient },
+  },
+  {
+    moduleRef: "constitute-nvr-ui/nvr-projection-model@0.2.0",
+    role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+    version: "0.2.0",
+    implementation: {
+      cameraCountForContext,
+      humanizeSourceId,
+      normalizeRuntimeCameraEntries,
+      normalizeSourceIds,
+      nvrDisplayFromRecord,
+    },
+  },
+  {
+    moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+    version: "0.1.0",
+    implementation: {
+      applyBrowserStreamAnswer,
+      applyBrowserStreamCandidate,
+      bindBrowserMediaStream,
+      browserStreamAvailable,
+      candidateKey,
+      collectBrowserMediaFulfillmentEvidence,
+      closeBrowserStreamSession,
+      createBrowserStreamOffer,
+      isRuntimeMediaTransportProfileFailure,
+      mediaFulfillmentEvidenceFromAdapterState,
+      mediaFulfillmentEvidenceFromRender,
+      mediaFulfillmentEvidenceFromTrack,
+      mediaFulfillmentReleaseEvidence,
+      mediaTransportObservationFromFulfillmentEvidence,
+      runtimeMediaIceServerUrls,
+      runtimeMediaIceServers,
+      runtimeMediaTransportBlockedDetail,
+      runtimeMediaTransportContract,
+    },
+  },
+  {
+    moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
+    role: SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER,
+    version: "0.2.0",
+    implementation: { createNvrAdminAdapter, normalizeNvrAdminAdapterError },
+  },
+  {
+    moduleRef: "constitute-nvr-ui/product-view@0.2.0",
+    role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+    version: "0.2.0",
+    implementation: { renderShell },
+  },
+]);
+
+export function requireNvrSurfaceModuleClaim(role: string, options: { moduleRef: string; primitiveRef?: string }) {
+  const posture = surfaceModuleRegistryPosture(nvrSurfaceModuleRegistry, nvrSurfaceApp, role, options);
+  if (posture.state !== "ready" || !posture.claim) {
+    throw new Error(`NVR surface module unavailable: ${posture.blockedReason} ${role} ${options.moduleRef}`.trim());
+  }
+  return posture.claim;
+}
+
+export const nvrSurfaceModules = Object.freeze({
+  runtimeClient: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT, {
+    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+    primitiveRef: "runtime.attach",
+  }),
+  projectionModel: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL, {
+    moduleRef: "constitute-nvr-ui/nvr-projection-model@0.2.0",
+    primitiveRef: "projection.materialization",
+  }),
+  platformAdapter: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER, {
+    moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
+    primitiveRef: "media.transport.path",
+  }),
+  serviceSurfaceAdapter: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER, {
+    moduleRef: "constitute-nvr-ui/service-surface-adapter@0.2.0",
+    primitiveRef: "stream.intent",
+  }),
+  productView: requireNvrSurfaceModuleClaim(SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW, {
+    moduleRef: "constitute-nvr-ui/product-view@0.2.0",
+    primitiveRef: "runtime.posture.render",
+  }),
+});
+
+export const nvrRuntimeClientModule = nvrSurfaceModules.runtimeClient.implementation;
+export const nvrProjectionModelModule = nvrSurfaceModules.projectionModel.implementation;
+export const nvrPlatformAdapterModule = nvrSurfaceModules.platformAdapter.implementation;
+export const nvrServiceSurfaceAdapterModule = nvrSurfaceModules.serviceSurfaceAdapter.implementation;
+export const nvrProductViewModule = nvrSurfaceModules.productView.implementation;
+
+export const nvrSurfaceBudgets = Object.freeze({
+  preview: requireSurfaceMaterializationBudget(nvrSurfaceApp, "nvr-ui.preview", {
+    payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.MEDIA,
+    copyRole: SWARM.MATERIALIZATION_COPY_ROLE.TRANSPORT,
+    transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.NATIVE,
+  }),
+  streamEvents: requireSurfaceMaterializationBudget(nvrSurfaceApp, "nvr-ui.stream-events", {
+    payloadClass: SWARM.MATERIALIZATION_PAYLOAD_CLASS.EVIDENCE,
+    copyRole: SWARM.MATERIALIZATION_COPY_ROLE.BUFFER,
+    transferMode: SWARM.MATERIALIZATION_TRANSFER_MODE.REFERENCE_ONLY,
+  }),
+});
+
+export const NVR_PREVIEW_SOURCE_LIMIT = Math.max(
+  1,
+  materializationBudgetLimit(
+    nvrSurfaceBudgets.preview,
+    "maxActivePreviews",
+    materializationBudgetLimit(nvrSurfaceBudgets.preview, "maxItems", 2),
+  ),
+);
+
+export const NVR_STREAM_EVENT_LIMIT = Math.max(
+  1,
+  materializationBudgetLimit(nvrSurfaceBudgets.streamEvents, "maxItems", 240),
+);

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -115,16 +115,18 @@ test("nvr ui activates runtime stream intents without owning browser transport s
 
 test("nvr ui attaches to the account-owned runtime worker contract", () => {
   const main = source("constitute-nvr-ui/src/main.ts");
+  const modules = source("constitute-nvr-ui/src/surface-modules.ts");
 
-  assert.match(main, /createRuntimeSurfaceClient/);
-  assert.match(main, /createSurfaceModuleRegistry/);
-  assert.match(main, /surfaceModuleRegistryPosture/);
-  assert.match(main, /from "\.\.\/\.\.\/constitute-ui\/src\/runtime-surface-client\.js"/);
-  assert.match(main, /from "\.\.\/\.\.\/constitute-ui\/src\/surface-module-registry\.js"/);
+  assert.match(modules, /createRuntimeSurfaceClient/);
+  assert.match(modules, /createSurfaceModuleRegistry/);
+  assert.match(modules, /surfaceModuleRegistryPosture/);
+  assert.match(modules, /from "\.\.\/\.\.\/constitute-ui\/src\/runtime-surface-client\.js"/);
+  assert.match(modules, /from "\.\.\/\.\.\/constitute-ui\/src\/surface-module-registry\.js"/);
   assert.match(main, /from "\.\/surface-app-contract\.js"/);
+  assert.match(main, /from "\.\/surface-modules"/);
   assert.match(main, /nvrSurfaceModules/);
-  assert.match(main, /nvrSurfaceModuleRegistry/);
-  assert.match(main, /requireNvrSurfaceModuleClaim/);
+  assert.match(modules, /nvrSurfaceModuleRegistry/);
+  assert.match(modules, /requireNvrSurfaceModuleClaim/);
   assert.match(main, /activeRuntimeClientModuleRef/);
   assert.match(main, /attachContext: nvrRuntimeAttachContext/);
   assert.match(main, /from "\.\.\/\.\.\/constitute-account\/runtime-contract\.js"/);
@@ -139,7 +141,11 @@ test("nvr ui attaches to the account-owned runtime worker contract", () => {
   assert.match(main, /accountRuntimeWorkerScriptUrl\(window\.location\.origin\)/);
   assert.match(main, /runtimeAttachDebugInfo\(window\.location\.origin\)/);
   assert.match(main, /const RUNTIME_ATTACH_TIMEOUT_MS = 12_000/);
-  assert.match(main, /let runtimeClient: ReturnType<typeof createRuntimeSurfaceClient> \| null = null/);
+  assert.match(main, /let runtimeClient: ReturnType<typeof nvrRuntimeClientModule\.createRuntimeSurfaceClient> \| null = null/);
+  assert.match(main, /nvrRuntimeClientModule\.createRuntimeSurfaceClient/);
+  assert.doesNotMatch(main, /from "\.\.\/\.\.\/constitute-ui\/src\/runtime-surface-client\.js"/);
+  assert.doesNotMatch(main, /createSurfaceModuleRegistry/);
+  assert.doesNotMatch(main, /surfaceModuleRegistryPosture/);
   assert.match(main, /runtimeClient\.waitUntilAttached\(RUNTIME_ATTACH_TIMEOUT_MS\)/);
   assert.match(main, /runtimeClient\.call\(type, payload, timeoutMs\)/);
   assert.doesNotMatch(main, /pendingRuntimeResponses/);
@@ -162,10 +168,12 @@ test("nvr ui declares a surface app contract", async () => {
 
 test("nvr service administration uses a service-surface adapter boundary", () => {
   const main = source("constitute-nvr-ui/src/main.ts");
+  const modules = source("constitute-nvr-ui/src/surface-modules.ts");
   const adminAdapter = source("constitute-nvr-ui/src/nvr-admin-adapter.ts");
 
-  assert.match(main, /from "\.\/nvr-admin-adapter"/);
-  assert.match(main, /createNvrAdminAdapter/);
+  assert.match(modules, /from "\.\/nvr-admin-adapter"/);
+  assert.match(modules, /createNvrAdminAdapter/);
+  assert.match(main, /nvrServiceSurfaceAdapterModule/);
   assert.match(main, /nvrAdminAdapter\.request\("list_camera_device_inventory"/);
   assert.match(main, /nvrAdminAdapter\.request\("apply_camera_device_config"/);
   assert.match(main, /nvrAdminAdapter\.request\("mount_camera_device"/);
@@ -173,6 +181,7 @@ test("nvr service administration uses a service-surface adapter boundary", () =>
   assert.doesNotMatch(main, /function requestNvrAdminAdapterAction/);
   assert.doesNotMatch(main, /function normalizeAdminError/);
   assert.doesNotMatch(main, /action === "apply_camera_device_config"\s+\?\s+CAMERA_APPLY_REQUEST_TIMEOUT_MS/);
+  assert.doesNotMatch(main, /from "\.\/nvr-admin-adapter"/);
   assert.match(adminAdapter, /export function createNvrAdminAdapter/);
   assert.match(adminAdapter, /export function normalizeNvrAdminAdapterError/);
   assert.match(adminAdapter, /export function nvrAdminActionTimeoutMs/);
@@ -185,9 +194,11 @@ test("nvr service administration uses a service-surface adapter boundary", () =>
 
 test("nvr projection model owns camera display normalization", () => {
   const main = source("constitute-nvr-ui/src/main.ts");
+  const modules = source("constitute-nvr-ui/src/surface-modules.ts");
   const projectionModel = source("constitute-nvr-ui/src/nvr-projection-model.ts");
 
-  assert.match(main, /from "\.\/nvr-projection-model"/);
+  assert.match(modules, /from "\.\/nvr-projection-model"/);
+  assert.match(main, /nvrProjectionModelModule/);
   assert.match(projectionModel, /export const NVR_AUTO_PREVIEW_SOURCE_ID/);
   assert.match(projectionModel, /export function normalizeSourceIds/);
   assert.match(projectionModel, /export function humanizeSourceId/);

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -117,10 +117,14 @@ test("nvr ui attaches to the account-owned runtime worker contract", () => {
   const main = source("constitute-nvr-ui/src/main.ts");
 
   assert.match(main, /createRuntimeSurfaceClient/);
-  assert.match(main, /requireSurfaceModuleRole/);
+  assert.match(main, /createSurfaceModuleRegistry/);
+  assert.match(main, /surfaceModuleRegistryPosture/);
   assert.match(main, /from "\.\.\/\.\.\/constitute-ui\/src\/runtime-surface-client\.js"/);
+  assert.match(main, /from "\.\.\/\.\.\/constitute-ui\/src\/surface-module-registry\.js"/);
   assert.match(main, /from "\.\/surface-app-contract\.js"/);
   assert.match(main, /nvrSurfaceModules/);
+  assert.match(main, /nvrSurfaceModuleRegistry/);
+  assert.match(main, /requireNvrSurfaceModuleClaim/);
   assert.match(main, /activeRuntimeClientModuleRef/);
   assert.match(main, /attachContext: nvrRuntimeAttachContext/);
   assert.match(main, /from "\.\.\/\.\.\/constitute-account\/runtime-contract\.js"/);

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -127,6 +127,8 @@ test("nvr ui attaches to the account-owned runtime worker contract", () => {
   assert.match(main, /nvrSurfaceModules/);
   assert.match(modules, /nvrSurfaceModuleRegistry/);
   assert.match(modules, /requireNvrSurfaceModuleClaim/);
+  assert.match(modules, /requireNvrSurfaceModuleBinding/);
+  assert.match(modules, /const implementation = posture\.implementation\?\.implementation/);
   assert.match(main, /activeRuntimeClientModuleRef/);
   assert.match(main, /attachContext: nvrRuntimeAttachContext/);
   assert.match(main, /from "\.\.\/\.\.\/constitute-account\/runtime-contract\.js"/);


### PR DESCRIPTION
## Summary
- Resolve NVR UI surface modules through the shared surface module registry.
- Keep runtime client, projection model, WebRTC platform adapter, service-surface adapter, and product view selected by app-contract role posture.
- Point the UI dependency at the active surface SDK registry branch.

## Tests
- npm run test:source
- npm run build