### PR TITLE
Declare NVR UI service manager posture

### DIFF
--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,5 +1,10 @@
 import { SURFACE_APP, SWARM, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
-import { defineSurfaceAppContract } from "../../constitute-ui/src/surface-app-contract.js";
+import {
+  defineSurfaceAppContract,
+  surfaceAppBootstrapPosture,
+  surfaceServiceManagerOperationPosture,
+  surfaceServiceManagerProofDigest,
+} from "../../constitute-ui/src/surface-app-contract.js";
 
 const ISSUED_AT = 1700000000;
 
@@ -130,6 +135,23 @@ export const nvrSurfaceAppContract = assertSurfaceAppContract({
     state: SURFACE_APP.UPDATE_POSTURE.STATIC,
     checkedAt: ISSUED_AT,
   },
+  serviceManagerPosture: {
+    managerId: "manager:manual:nvr-ui",
+    subjectRef: "service:nvr",
+    managerRef: "manager:manual:nvr-ui",
+    state: SURFACE_APP.SERVICE_MANAGER_POSTURE.MANUAL,
+    serviceRefs: ["service:nvr"],
+    capabilityRefs: ["service.manage"],
+    evidenceRefs: ["build:nvr-ui:local"],
+    issuedAt: ISSUED_AT,
+  },
+  secretBoundary: {
+    state: SURFACE_APP.SECRET_BOUNDARY.NOT_REQUIRED,
+  },
+  releasePosture: {
+    state: SURFACE_APP.RELEASE_POSTURE.STATIC,
+    evidenceRefs: ["build:nvr-ui:local"],
+  },
   issuedAt: ISSUED_AT,
 });
 
@@ -137,6 +159,25 @@ export const nvrSurfaceApp = defineSurfaceAppContract(nvrSurfaceAppContract, {
   validate: assertSurfaceAppContract,
 });
 
+export const nvrSurfaceBootstrapPosture = surfaceAppBootstrapPosture(nvrSurfaceApp, {
+  issuedAt: ISSUED_AT,
+});
+
+export const nvrServiceManagerOperationPosture = surfaceServiceManagerOperationPosture(nvrSurfaceApp, {
+  operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.HEALTH_CHECK,
+  operationId: "operation:nvr-ui:bootstrap-health",
+  requestedAt: ISSUED_AT,
+});
+
+export const nvrServiceManagerProofDigest = surfaceServiceManagerProofDigest(nvrSurfaceApp, {
+  operationPosture: nvrServiceManagerOperationPosture,
+  digestId: "proof-digest:nvr-ui:bootstrap",
+  observedAt: ISSUED_AT,
+});
+
 export const nvrSurfaceAttachContext = nvrSurfaceApp.attachContext({
   productSurface: "constitute-nvr-ui",
+  bootstrapPosture: nvrSurfaceBootstrapPosture,
+  serviceManagerOperationPosture: nvrServiceManagerOperationPosture,
+  serviceManagerProofDigest: nvrServiceManagerProofDigest,
 });

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -157,7 +157,13 @@ test("nvr ui attaches to the account-owned runtime worker contract", () => {
 });
 
 test("nvr ui declares a surface app contract", async () => {
-  const { nvrSurfaceApp, nvrSurfaceAttachContext } = await import("../src/surface-app-contract.js");
+  const {
+    nvrServiceManagerOperationPosture,
+    nvrServiceManagerProofDigest,
+    nvrSurfaceApp,
+    nvrSurfaceAttachContext,
+    nvrSurfaceBootstrapPosture,
+  } = await import("../src/surface-app-contract.js");
   assert.equal(nvrSurfaceApp.posture.state, "ready");
   assert.equal(nvrSurfaceApp.hasRole("runtimeClient"), true);
   assert.equal(nvrSurfaceApp.hasRole("projectionModel"), true);
@@ -166,6 +172,11 @@ test("nvr ui declares a surface app contract", async () => {
   assert.equal(nvrSurfaceApp.hasRole("productView"), true);
   assert.equal(nvrSurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(nvrSurfaceAttachContext.appId, "constitute-nvr-ui");
+  assert.equal(nvrSurfaceBootstrapPosture.state, "ready");
+  assert.equal(nvrServiceManagerOperationPosture.kind, "service.manager.operation.posture");
+  assert.equal(nvrServiceManagerOperationPosture.state, "requested");
+  assert.equal(nvrServiceManagerProofDigest.kind, "service.manager.proof.digest");
+  assert.equal(nvrSurfaceAttachContext.serviceManagerOperationPosture, nvrServiceManagerOperationPosture);
 });
 
 test("nvr service administration uses a service-surface adapter boundary", () => {


### PR DESCRIPTION
## Summary
- Declare NVR UI service-manager posture through the shared surface contract pattern.
- Preserve NVR as the media proof fixture while keeping transport policy in shared surface/runtime contracts.

## Checks
- NVR live proof passed with two advancing 640x360 streams.
- Root browser smoke passed.
- Root check:all passed locally.