### PR TITLE
Attach NVR surface app contract

### DIFF
--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -1,6 +1,13 @@
-import { SURFACE_APP, SWARM, assertSurfaceAppContract } from "../../constitute-protocol/src/index.js";
+import {
+  SURFACE_APP,
+  SWARM,
+  assertServiceManagerSecretBoundary,
+  assertSurfaceAppBootstrapContract,
+  assertSurfaceAppContract,
+} from "../../constitute-protocol/src/index.js";
 import {
   defineSurfaceAppContract,
+  surfaceAppRunnerPlan,
   surfaceAppBootstrapPosture,
   surfaceServiceManagerOperationPosture,
   surfaceServiceManagerProofDigest,
@@ -159,6 +166,18 @@ export const nvrSurfaceApp = defineSurfaceAppContract(nvrSurfaceAppContract, {
   validate: assertSurfaceAppContract,
 });
 
+export const nvrSurfaceRunnerPlan = surfaceAppRunnerPlan(nvrSurfaceApp, {
+  issuedAt: ISSUED_AT,
+});
+
+export const nvrServiceManagerSecretBoundary = assertServiceManagerSecretBoundary(
+  nvrSurfaceRunnerPlan.secretBoundary,
+);
+
+export const nvrSurfaceBootstrapContract = assertSurfaceAppBootstrapContract(
+  nvrSurfaceRunnerPlan.bootstrapContract,
+);
+
 export const nvrSurfaceBootstrapPosture = surfaceAppBootstrapPosture(nvrSurfaceApp, {
   issuedAt: ISSUED_AT,
 });
@@ -177,6 +196,9 @@ export const nvrServiceManagerProofDigest = surfaceServiceManagerProofDigest(nvr
 
 export const nvrSurfaceAttachContext = nvrSurfaceApp.attachContext({
   productSurface: "constitute-nvr-ui",
+  runnerPlan: nvrSurfaceRunnerPlan,
+  bootstrapContract: nvrSurfaceBootstrapContract,
+  serviceManagerSecretBoundary: nvrServiceManagerSecretBoundary,
   bootstrapPosture: nvrSurfaceBootstrapPosture,
   serviceManagerOperationPosture: nvrServiceManagerOperationPosture,
   serviceManagerProofDigest: nvrServiceManagerProofDigest,

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -160,9 +160,12 @@ test("nvr ui declares a surface app contract", async () => {
   const {
     nvrServiceManagerOperationPosture,
     nvrServiceManagerProofDigest,
+    nvrServiceManagerSecretBoundary,
     nvrSurfaceApp,
     nvrSurfaceAttachContext,
+    nvrSurfaceBootstrapContract,
     nvrSurfaceBootstrapPosture,
+    nvrSurfaceRunnerPlan,
   } = await import("../src/surface-app-contract.js");
   assert.equal(nvrSurfaceApp.posture.state, "ready");
   assert.equal(nvrSurfaceApp.hasRole("runtimeClient"), true);
@@ -173,9 +176,17 @@ test("nvr ui declares a surface app contract", async () => {
   assert.equal(nvrSurfaceAttachContext.kind, "surface.app.attachContext");
   assert.equal(nvrSurfaceAttachContext.appId, "constitute-nvr-ui");
   assert.equal(nvrSurfaceBootstrapPosture.state, "ready");
+  assert.equal(nvrSurfaceRunnerPlan.kind, "surface.app.runner.plan");
+  assert.equal(nvrSurfaceRunnerPlan.state, "ready");
+  assert.equal(nvrSurfaceBootstrapContract.kind, "surface.app.bootstrap.contract");
+  assert.equal(nvrSurfaceBootstrapContract.state, "ready");
+  assert.equal(nvrServiceManagerSecretBoundary.kind, "service.manager.secretBoundary");
+  assert.equal(nvrServiceManagerSecretBoundary.state, "notRequired");
   assert.equal(nvrServiceManagerOperationPosture.kind, "service.manager.operation.posture");
   assert.equal(nvrServiceManagerOperationPosture.state, "requested");
   assert.equal(nvrServiceManagerProofDigest.kind, "service.manager.proof.digest");
+  assert.equal(nvrSurfaceAttachContext.runnerPlan, nvrSurfaceRunnerPlan);
+  assert.equal(nvrSurfaceAttachContext.bootstrapContract, nvrSurfaceBootstrapContract);
   assert.equal(nvrSurfaceAttachContext.serviceManagerOperationPosture, nvrServiceManagerOperationPosture);
 });
 


### PR DESCRIPTION
## Summary
- declare the NVR UI as a surface app contract
- consume shared runtime, projection model, service-surface, and media adapter module roles
- keep stream proof on route, service acceptance, answer materialization, and adapter evidence

## Tests
- NVR UI source tests and build
- root convergence and affected checks
- browser smoke and 10-minute stream collection