### PR TITLE
Use shared adapter lifecycle posture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -876,7 +876,7 @@
     },
     "node_modules/constitute-protocol": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#3a452b5f9482f28ebd07f17549cba15b6355d530",
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-protocol.git#d75e53e8b31674b34e8cd57621c1fb508d70a1eb",
       "dependencies": {
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.1",
@@ -885,7 +885,7 @@
     },
     "node_modules/constitute-ui": {
       "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#3a677aa320282325b8def8be82473279bd70e0b8"
+      "resolved": "git+ssh://git@github.com/Aux0x7F/constitute-ui.git#52759e1325d4151712ddc13ec27516bf72066462"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",

--- a/src/browser-stream-adapter.ts
+++ b/src/browser-stream-adapter.ts
@@ -24,7 +24,7 @@ export {
   runtimeMediaTransportBlockedDetail,
   runtimeMediaTransportContract,
   shouldReportMediaFulfillmentEvidence,
-} from "../../constitute-ui/src/media-webrtc-adapter.ts";
+} from "constitute-ui/media-webrtc-adapter";
 
 export type {
   BrowserStreamAdapterOptions,
@@ -35,4 +35,4 @@ export type {
   MediaWebRtcAdapterBindingProfile,
   RuntimeMediaTransportProfile,
   SurfaceAdapterBindingPosture,
-} from "../../constitute-ui/src/media-webrtc-adapter.ts";
+} from "constitute-ui/media-webrtc-adapter";

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,12 @@ import {
 import { RUNTIME_DIAGNOSTIC_OPERATOR_PLANES, attachRuntimeDiagnostics } from "../../constitute-account/runtime-diagnostics.js";
 import { browserStorageShellContext, deriveRuntimeShellState } from "constitute-ui/runtime-shell-state";
 import {
+  adapterReconnectDelayMs,
+  adapterReconnectJitterMs,
+  adapterReconnectLifecyclePosture,
+  adapterReleaseLifecyclePosture,
+} from "constitute-ui/adapter-lifecycle";
+import {
   applyRuntimeActivationPostureToStreamSession,
   applyRuntimeMediaFulfillmentPostureToStreamSession,
   applyRuntimeRouteObservationToStreamSession,
@@ -4765,9 +4771,12 @@ function cancelStreamLiveWatchdog(): void {
 }
 
 function reconnectDelayMs(attempt: number, baseMs: number, maxMs: number): number {
-  const step = Math.min(5, Math.max(0, attempt - 1));
-  const jitter = Math.floor(Math.random() * Math.min(1_000, baseMs));
-  return Math.min(maxMs, (baseMs * (2 ** step)) + jitter);
+  return adapterReconnectDelayMs(
+    attempt,
+    baseMs,
+    maxMs,
+    adapterReconnectJitterMs(baseMs),
+  );
 }
 
 type RuntimeStreamRecoveryPosture = {
@@ -4783,6 +4792,54 @@ function runtimeStreamRecoveryParentIntentId(context: RuntimeServiceContext | nu
   if (!context) return RUNTIME_STREAM_RECOVERY_PARENT_INTENT_ID;
   const sourceKey = runtimePreviewSourceIds(context).join(",");
   return sourceKey ? `${RUNTIME_STREAM_RECOVERY_PARENT_INTENT_ID}:${sourceKey}` : RUNTIME_STREAM_RECOVERY_PARENT_INTENT_ID;
+}
+
+function platformAdapterLifecycleRef(): string {
+  return String(nvrPlatformAdapterBindingPosture.implementationRef || nvrSurfaceModules.platformAdapter.moduleRef || "adapter:media-webrtc:browser");
+}
+
+function adapterReconnectLifecycle(
+  reason: string,
+  attempt: number,
+  delayMs: number,
+  context: RuntimeServiceContext | null = runtimeServiceContext,
+): Record<string, unknown> {
+  return adapterReconnectLifecyclePosture({
+    adapterRef: platformAdapterLifecycleRef(),
+    moduleRef: nvrSurfaceModules.platformAdapter.moduleRef,
+    surfaceRef: nvrSurfaceApp.surfaceRef || nvrSurfaceApp.contractId,
+    subjectRef: runtimeStreamRecoveryParentIntentId(context),
+    intentRefs: [runtimeStreamRecoveryParentIntentId(context)],
+    sessionRefs: activeRuntimeStreamSessions().map((session) => session.sessionId),
+    releaseRefs: nvrPlatformAdapterBindingPosture.releaseRefs,
+    resourceRefs: nvrPlatformAdapterBindingPosture.materializationBudgetRefs,
+    attempt,
+    delayMs,
+    reason,
+    openResourceCount: activeRuntimeStreamSessions().length,
+    safeFacts: {
+      sourceCount: context ? runtimePreviewSourceIds(context).length : 0,
+      adapterRole: nvrPlatformAdapterBindingPosture.role,
+    },
+  });
+}
+
+function adapterReleaseLifecycle(session: RuntimeStreamSession, reasonCode: string): Record<string, unknown> {
+  return adapterReleaseLifecyclePosture({
+    adapterRef: session.adapterModuleRef || platformAdapterLifecycleRef(),
+    moduleRef: nvrSurfaceModules.platformAdapter.moduleRef,
+    surfaceRef: nvrSurfaceApp.surfaceRef || nvrSurfaceApp.contractId,
+    subjectRef: session.sessionId,
+    sessionRefs: [session.sessionId],
+    releaseRefs: session.releaseRefs.length ? session.releaseRefs : nvrPlatformAdapterBindingPosture.releaseRefs,
+    resourceRefs: nvrPlatformAdapterBindingPosture.materializationBudgetRefs,
+    safeFacts: {
+      reasonCode,
+      sourceRef: session.sourceId,
+      iceConnectionState: session.iceConnectionState,
+      connectionState: session.connectionState,
+    },
+  });
 }
 
 async function runtimeStreamRecoveryPosture(
@@ -4806,6 +4863,7 @@ async function runtimeStreamRecoveryPosture(
         fallbackDelayMs,
         sourceIds: runtimePreviewSourceIds(context),
         sessionCount: activeRuntimeStreamSessions().length,
+        adapterLifecycle: adapterReconnectLifecycle(reason, attempt, fallbackDelayMs, context),
       },
     }, RUNTIME_WRITE_TIMEOUT_MS);
     return (posture && typeof posture === "object") ? posture : { state: "localFallback", attempt, delayMs: fallbackDelayMs, reason };
@@ -5133,6 +5191,7 @@ function publishRuntimeStreamSessionClose(session: RuntimeStreamSession, reasonC
     sessionId: session.sessionId,
     sourceId: session.sourceId,
     reasonCode,
+    adapterLifecycle: adapterReleaseLifecycle(session, reasonCode),
   }).catch((error) => {
     appendLog(`queued stream close failed: ${String((error as Error)?.message || error)}`);
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import "constitute-ui/styles.css";
 import "./styles.css";
 import { renderActionList, setConnectionStateText } from "constitute-ui";
-import { createKeyValueGrid } from "../../constitute-ui/src/index.js";
+import { createKeyValueGrid } from "constitute-ui";
 import { nvrSurfaceApp, nvrSurfaceAttachContext } from "./surface-app-contract.js";
 import {
   NVR_PREVIEW_SOURCE_LIMIT,
@@ -32,7 +32,7 @@ import {
   runtimeWorkerScriptUrl as accountRuntimeWorkerScriptUrl,
 } from "../../constitute-account/runtime-contract.js";
 import { RUNTIME_DIAGNOSTIC_OPERATOR_PLANES, attachRuntimeDiagnostics } from "../../constitute-account/runtime-diagnostics.js";
-import { browserStorageShellContext, deriveRuntimeShellState } from "../../constitute-ui/src/runtime-shell-state.js";
+import { browserStorageShellContext, deriveRuntimeShellState } from "constitute-ui/runtime-shell-state";
 import {
   applyRuntimeActivationPostureToStreamSession,
   applyRuntimeMediaFulfillmentPostureToStreamSession,
@@ -48,8 +48,8 @@ import {
   runtimeIntentWaitingAuthority,
   runtimeRouteObservationPosture,
   runtimeStreamSessionPosture as summarizeRuntimeStreamSessionPosture,
-} from "../../constitute-ui/src/runtime-stream-session.js";
-import { preparedServiceRegistryServices } from "../../constitute-ui/src/service-registry-model.js";
+} from "constitute-ui/runtime-stream-session";
+import { preparedServiceRegistryServices } from "constitute-ui";
 import {
   MEDIA_RENDER_BLOCKED_GRACE_MS,
   MEDIA_RENDER_WAITING_GRACE_MS,
@@ -69,7 +69,7 @@ import {
   streamSessionLifecycleRecordFromCarrier,
   type MediaFulfillmentEvidence,
   type MediaTransportObservation,
-} from "../../constitute-protocol/src/index.js";
+} from "constitute-protocol";
 
 const {
   applyBrowserStreamAnswer,

--- a/src/nvr-admin-adapter.ts
+++ b/src/nvr-admin-adapter.ts
@@ -3,7 +3,7 @@ import {
   normalizeServiceSurfaceAdapterError,
   serviceSurfaceActionTimeoutMs,
   type ServiceSurfaceAdapterPosture,
-} from "../../constitute-ui/src/service-surface-adapter.js";
+} from "constitute-ui/service-surface-adapter";
 
 export type NvrAdminAdapterPayload = Record<string, unknown>;
 export type NvrAdminAdapterResult = Record<string, unknown>;

--- a/src/surface-app-contract.js
+++ b/src/surface-app-contract.js
@@ -3,11 +3,11 @@ import {
   SWARM,
   assertSurfaceAppManifest,
   assertSurfaceAppContract,
-} from "../../constitute-protocol/src/index.js";
+} from "constitute-protocol";
 import {
   defineSurfaceAppContract,
-} from "../../constitute-ui/src/surface-app-contract.js";
-import { surfaceAppSelectionReadModel } from "../../constitute-ui/src/surface-selection-read-model.js";
+} from "constitute-ui/surface-app-contract";
+import { surfaceAppSelectionReadModel } from "constitute-ui/surface-selection-read-model";
 
 const ISSUED_AT = 1700000000;
 

--- a/src/surface-modules.ts
+++ b/src/surface-modules.ts
@@ -1,8 +1,8 @@
-import { createRuntimeSurfaceClient } from "../../constitute-ui/src/runtime-surface-client.js";
+import { createRuntimeSurfaceClient } from "constitute-ui/runtime-surface-client";
 import {
   materializationBudgetLimit,
   requireSurfaceMaterializationBudget,
-} from "../../constitute-ui/src/surface-app-contract.js";
+} from "constitute-ui/surface-app-contract";
 import {
   createSurfaceModuleRegistry,
   requireSurfaceModuleBinding,
@@ -10,8 +10,8 @@ import {
   surfacePlatformAdapterBindingPosture,
   surfaceServiceSurfaceAdapterBindingPosture,
   surfaceModuleRegistryPosture,
-} from "../../constitute-ui/src/surface-module-registry.js";
-import { SURFACE_APP, SWARM } from "../../constitute-protocol/src/index.js";
+} from "constitute-ui/surface-module-registry";
+import { SURFACE_APP, SWARM } from "constitute-protocol";
 import { renderShell } from "./shell";
 import { nvrSurfaceApp, nvrSurfaceRuntimeSelectionPosture } from "./surface-app-contract.js";
 import {

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -87,6 +87,12 @@ test("nvr ui activates runtime stream intents without owning browser transport s
   assert.match(main, /runtimeStreamRecoveryPosture/);
   assert.match(main, /resetRuntimeStreamRecovery/);
   assert.match(main, /runtimeStreamRecoveryParentIntentId/);
+  assert.match(main, /constitute-ui\/adapter-lifecycle/);
+  assert.match(main, /adapterReconnectLifecyclePosture/);
+  assert.match(main, /adapterReleaseLifecyclePosture/);
+  assert.match(main, /adapterLifecycle: adapterReconnectLifecycle/);
+  assert.match(main, /adapterLifecycle: adapterReleaseLifecycle/);
+  assert.doesNotMatch(main, /Math\.random\(\) \* Math\.min\(1_000, baseMs\)/);
   assert.doesNotMatch(main, /tile\.video\.srcObject = stream/);
   assert.match(main, /applyRuntimeRouteObservationToStreamSession/);
   assert.match(streamSession, /memberWritten/);

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -29,7 +29,7 @@ test("nvr ui activates runtime stream intents without owning browser transport s
   assert.match(runtimeContract, /RUNTIME_STREAM_RECOVERY_REQUEST = "runtime\.stream\.recovery\.request"/);
   assert.match(main, /publishRuntimeStreamIntent/);
   assert.match(main, /preparedStreamStatus/);
-  assert.match(main, /runtime-stream-session\.js/);
+  assert.match(main, /constitute-ui\/runtime-stream-session/);
   assert.match(main, /streamSessionLifecycleRecordFromCarrier/);
   assert.match(main, /STREAM_SESSION_LIFECYCLE_PHASE/);
   assert.doesNotMatch(main, /recordKind\.endsWith\("\.(admission|reject|answer|candidate|health)"\)/);
@@ -51,7 +51,8 @@ test("nvr ui activates runtime stream intents without owning browser transport s
   assert.doesNotMatch(main, /pc\.createOffer/);
   assert.doesNotMatch(main, /pc\.onicecandidate/);
   assert.doesNotMatch(nvrAdapter, /new RTCPeerConnection/);
-  assert.match(nvrAdapter, /constitute-ui\/src\/media-webrtc-adapter/);
+  assert.match(nvrAdapter, /constitute-ui\/media-webrtc-adapter/);
+  assert.doesNotMatch(nvrAdapter, /constitute-ui\/src\/media-webrtc-adapter/);
   assert.match(adapter, /new RTCPeerConnection/);
   assert.match(adapter, /createBrowserStreamOffer/);
   assert.match(adapter, /adapter:media-webrtc:browser/);
@@ -123,8 +124,10 @@ test("nvr ui attaches to the account-owned runtime worker contract", () => {
   assert.match(modules, /surfaceAppModuleBindings/);
   assert.match(modules, /surfaceModuleRegistryPosture/);
   assert.match(modules, /requireSurfaceModuleBinding/);
-  assert.match(modules, /from "\.\.\/\.\.\/constitute-ui\/src\/runtime-surface-client\.js"/);
-  assert.match(modules, /from "\.\.\/\.\.\/constitute-ui\/src\/surface-module-registry\.js"/);
+  assert.match(modules, /from "constitute-ui\/runtime-surface-client"/);
+  assert.match(modules, /from "constitute-ui\/surface-module-registry"/);
+  assert.doesNotMatch(modules, /from "\.\.\/\.\.\/constitute-ui\/src\/runtime-surface-client\.js"/);
+  assert.doesNotMatch(modules, /from "\.\.\/\.\.\/constitute-ui\/src\/surface-module-registry\.js"/);
   assert.match(main, /from "\.\/surface-app-contract\.js"/);
   assert.match(main, /from "\.\/surface-modules"/);
   assert.match(main, /nvrSurfaceModules/);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vite";
+import { fileURLToPath } from "node:url";
+
+const localUiAdapterLifecycle = fileURLToPath(new URL("../constitute-ui/src/adapter-lifecycle.js", import.meta.url));
 
 export default defineConfig({
   base: "./",
   resolve: {
     preserveSymlinks: true,
+    alias: {
+      "constitute-ui/adapter-lifecycle": localUiAdapterLifecycle,
+    },
   },
 });


### PR DESCRIPTION
## Summary
- Routes stream adapter lifecycle through shared posture and packaged surface helpers.
- Keeps NVR focused on camera inventory and stream intent proof while generic media lifecycle remains reusable.

## Proof
- Package build passed locally.
- Root docs, convergence, affected, browser, native, and all checks passed in the full train.
- Browser landscape proof passed with two active media elements, live tracks, nonzero video dimensions, and moving playback evidence.