### PR TITLE
Adopt NVR surface read model posture

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -59,7 +59,7 @@ import {
   runtimeRouteObservationPosture,
   runtimeStreamSessionPosture as summarizeRuntimeStreamSessionPosture,
 } from "constitute-ui/runtime-stream-session";
-import { preparedServiceRegistryServices } from "constitute-ui";
+import { prepareServiceHostFabricPosture, preparedServiceRegistryServices } from "constitute-ui";
 import {
   MEDIA_RENDER_BLOCKED_GRACE_MS,
   MEDIA_RENDER_WAITING_GRACE_MS,
@@ -1957,7 +1957,7 @@ function contextFromRuntimeRecord(record: ManagedApplianceRecord, snapshot: Runt
   const browserDevicePk = String(identity.devicePk || identity.device_pk || identity.browserDevicePk || "").trim();
   const discoveryScope = runtimeDiscoveryScopeFromRecord(record, snapshot, gatewayPk);
   const hostFabric = record.hostFabric && typeof record.hostFabric === "object" && !Array.isArray(record.hostFabric)
-    ? record.hostFabric as Record<string, unknown>
+    ? prepareServiceHostFabricPosture(record.hostFabric as Record<string, unknown>)
     : null;
   return {
     contextId,
@@ -2989,10 +2989,10 @@ function nvrServiceCatalogBlockedReason(record: ManagedApplianceRecord): string 
     return String(legacyFallback.reason || "Security Cameras service is projected from a quarantined legacy path.").trim();
   }
   const fabric = record.hostFabric && typeof record.hostFabric === "object" && !Array.isArray(record.hostFabric)
-    ? record.hostFabric as Record<string, unknown>
+    ? prepareServiceHostFabricPosture(record.hostFabric as Record<string, unknown>)
     : null;
   if (!fabric) return "";
-  const state = String(fabric.state || fabric.fulfillmentState || fabric.lifecycleState || "").trim().toLowerCase();
+  const state = String(fabric.state || "").trim().toLowerCase();
   const blockedReasons = Array.isArray(fabric.blockedReasons)
     ? fabric.blockedReasons.map((reason) => String(reason || "").trim()).filter(Boolean)
     : [];

--- a/src/main.ts
+++ b/src/main.ts
@@ -4186,6 +4186,8 @@ function renderRuntimePostureSummary(): string {
   const shellState = runtimeReadModel.shell as Record<string, any>;
   const resource = shellState.resource || {};
   const retention = shellState.retention || {};
+  const target = runtimeReadModel.target as Record<string, any> || {};
+  const fabric = runtimeReadModel.fabric as Record<string, any> || {};
   return `
     <section class="nestedPanel runtimePosturePanel">
       <div class="summaryLabel">Runtime Posture</div>
@@ -4194,6 +4196,8 @@ function renderRuntimePostureSummary(): string {
         ["Cleanup", resource.cleanupAllowed ? "allowed" : String(resource.cleanupReason || "blocked")],
         ["Retention", String(retention.state || "unknown")],
         ["Release", retention.releaseRequired ? String(retention.reason || "blocked") : "ready"],
+        ["Target", [String(target.state || "pending"), String(target.targetRef || "")].filter(Boolean).join(" / ")],
+        ["Fabric", [String(fabric.state || "pending"), String(fabric.planId || "")].filter(Boolean).join(" / ")],
       ])}
     </section>
   `;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2951,6 +2951,12 @@ function directEntryNvrServiceCatalogRecord(snapshot: RuntimeSnapshot | null): M
 }
 
 function nvrServiceCatalogBlockedReason(record: ManagedApplianceRecord): string {
+  const legacyFallback = record.legacyPathFallback && typeof record.legacyPathFallback === "object" && !Array.isArray(record.legacyPathFallback)
+    ? record.legacyPathFallback as Record<string, unknown>
+    : null;
+  if (legacyFallback) {
+    return String(legacyFallback.reason || "Security Cameras service is projected from a quarantined legacy path.").trim();
+  }
   const fabric = record.hostFabric && typeof record.hostFabric === "object" && !Array.isArray(record.hostFabric)
     ? record.hostFabric as Record<string, unknown>
     : null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -140,6 +140,11 @@ type RuntimeServiceContext = {
   service: string;
   discoveryScope?: RuntimeDiscoveryScope;
   hostFabric?: Record<string, unknown>;
+  legacyPathFallback?: {
+    state: "legacyPathFallback";
+    reason: string;
+    sourceRefs: string[];
+  };
   display?: RuntimeServiceDisplay;
   createdAt: number;
   expiresAt: number;
@@ -1769,6 +1774,11 @@ function localCachedNvrRuntimeContext(snapshot: RuntimeSnapshot | null): Runtime
     servicePk: applianceDevicePk(record),
     service: "nvr",
     ...(discoveryScope ? { discoveryScope } : {}),
+    legacyPathFallback: {
+      state: "legacyPathFallback",
+      reason: "account runtime snapshot unavailable; retained account cache selected service context",
+      sourceRefs: ["localStorage:swarm.deviceCache", "localStorage:constitute.gatewayHostedSnapshots"],
+    },
     display: nvrDisplayFromRecord(record),
     createdAt: Date.now(),
     expiresAt: Date.now() + (10 * 60_000),
@@ -5278,6 +5288,10 @@ async function activateRuntimeServiceContext(context: RuntimeServiceContext, sou
   directEntryRepairAttemptCount = 0;
   runtimeServiceContext = await persistRuntimeServiceContext(context);
   appendLog(`runtime context loaded for service ${pkLabel(runtimeServiceContext.servicePk)}${source ? ` (${source})` : ""}`);
+  if (runtimeServiceContext.legacyPathFallback) {
+    appendLog(`legacyPathFallback ${runtimeServiceContext.legacyPathFallback.reason}`);
+    void reportServiceStatus("degraded", runtimeServiceContext.legacyPathFallback.reason, "legacyPathFallback");
+  }
   markStartupStage("nvr.runtime-context.loaded");
   refreshSummary(runtimeServiceContext);
   applyNvrRuntimeProjections();

--- a/src/main.ts
+++ b/src/main.ts
@@ -139,6 +139,7 @@ type RuntimeServiceContext = {
   servicePk: string;
   service: string;
   discoveryScope?: RuntimeDiscoveryScope;
+  hostFabric?: Record<string, unknown>;
   display?: RuntimeServiceDisplay;
   createdAt: number;
   expiresAt: number;
@@ -1933,6 +1934,7 @@ function contextFromRuntimeRecord(record: ManagedApplianceRecord, snapshot: Runt
     servicePk,
     service: "nvr",
     ...(discoveryScope ? { discoveryScope } : {}),
+    ...(record.hostFabric && typeof record.hostFabric === "object" ? { hostFabric: record.hostFabric as Record<string, unknown> } : {}),
     display: nvrDisplayFromRecord(record),
     createdAt: Date.now(),
     expiresAt: Date.now() + (10 * 60_000),
@@ -1970,6 +1972,10 @@ async function requestDirectEntryRuntimeContext(): Promise<RuntimeServiceContext
   const gatewayPk = applianceGatewayPk(record);
   if (!servicePk || !gatewayPk) {
     throw runtimeContextError("runtime_directory", "Security Cameras runtime record did not include service and gateway identity");
+  }
+  const catalogBlockedReason = nvrServiceCatalogBlockedReason(record);
+  if (catalogBlockedReason) {
+    throw runtimeContextError("runtime_directory", catalogBlockedReason);
   }
   return contextFromRuntimeRecord(record, snapshot);
 }
@@ -2881,12 +2887,14 @@ function mergeNvrDirectoryRecords(
     label: String(catalogRecord.label || catalogRecord.deviceLabel || richerRecord.label || richerRecord.deviceLabel || "Security Cameras"),
     displayName: String(catalogRecord.displayName || catalogRecord.label || richerRecord.displayName || richerRecord.deviceLabel || "Security Cameras"),
     hostGatewayPk: String(richerRecord.hostGatewayPk || catalogRecord.hostGatewayPk || catalogRecord.gatewayPk || ""),
+    hostFabric: catalogRecord.hostFabric || richerRecord.hostFabric,
     updatedAt: Math.max(applianceUpdatedAt(catalogRecord), applianceUpdatedAt(richerRecord)),
   };
 }
 
 function directEntryNvrServiceRecord(snapshot: RuntimeSnapshot | null): ManagedApplianceRecord | null {
   const catalogRecord = directEntryNvrServiceCatalogRecord(snapshot);
+  if (!catalogRecord) return null;
   const records = snapshotManagedApplianceRecords(snapshot);
   const services = records
     .filter((record) => isNvrApplianceRecord(record) && applianceDevicePk(record) && applianceGatewayPk(record))
@@ -2905,7 +2913,7 @@ function directEntryNvrServiceRecord(snapshot: RuntimeSnapshot | null): ManagedA
   if (nvrRecordPreparedSourceCount(richerRecord) > nvrRecordPreparedSourceCount(catalogRecord)) {
     return mergeNvrDirectoryRecords(richerRecord, catalogRecord);
   }
-  return catalogRecord || richerRecord;
+  return catalogRecord;
 }
 
 function directEntryNvrServiceCatalogRecord(snapshot: RuntimeSnapshot | null): ManagedApplianceRecord | null {
@@ -2930,6 +2938,20 @@ function directEntryNvrServiceCatalogRecord(snapshot: RuntimeSnapshot | null): M
     serviceVersion: String(record.serviceVersion || record.version || ""),
     updatedAt: Number(record.updatedAt || snapshot?.updatedAt || Date.now()),
   };
+}
+
+function nvrServiceCatalogBlockedReason(record: ManagedApplianceRecord): string {
+  const fabric = record.hostFabric && typeof record.hostFabric === "object" && !Array.isArray(record.hostFabric)
+    ? record.hostFabric as Record<string, unknown>
+    : null;
+  if (!fabric) return "Security Cameras service is missing MSA host-fabric posture.";
+  const state = String(fabric.state || fabric.fulfillmentState || fabric.lifecycleState || "").trim().toLowerCase();
+  const blockedReasons = Array.isArray(fabric.blockedReasons)
+    ? fabric.blockedReasons.map((reason) => String(reason || "").trim()).filter(Boolean)
+    : [];
+  if (blockedReasons.length > 0) return `Security Cameras host fabric blocked: ${blockedReasons.slice(0, 2).join(", ")}`;
+  if (!state || state === "ready" || state === "available" || state === "live") return "";
+  return `Security Cameras host fabric is ${state}.`;
 }
 
 async function currentRuntimeSnapshot(): Promise<RuntimeSnapshot | null> {
@@ -4753,6 +4775,9 @@ async function loadRuntimeServiceContext(): Promise<RuntimeServiceContext> {
 function isDirectEntryIdleRuntimeFailure(error: RuntimeContextError): boolean {
   const detail = String(error.detail || "").toLowerCase();
   return detail.includes("no security cameras service is available")
+    || detail.includes("msa host-fabric posture")
+    || detail.includes("host fabric blocked")
+    || detail.includes("host fabric is")
     || detail.includes("shared browser runtime unavailable")
     || detail.includes("runtime broker unavailable")
     || detail.includes("runtime broker missing")

--- a/src/main.ts
+++ b/src/main.ts
@@ -1557,7 +1557,17 @@ async function waitForRuntimeAuthorityActionable(timeoutMs = RUNTIME_AUTHORITY_W
   return lastPosture;
 }
 
-function accountRuntimeNeedsIdentity(snapshot: RuntimeSnapshot | null): boolean {
+function runtimeShellIdentityFromSnapshot(snapshot: RuntimeSnapshot | null): Record<string, unknown> {
+  const readModel = prepareRuntimeReadModel((snapshot || {}) as Record<string, unknown>, runtimeReadModelOptions(runtimeServiceContext));
+  const shell = readModel.shell && typeof readModel.shell === "object"
+    ? readModel.shell as Record<string, unknown>
+    : {};
+  return shell.identity && typeof shell.identity === "object"
+    ? shell.identity as Record<string, unknown>
+    : {};
+}
+
+function rawSnapshotNeedsIdentity(snapshot: RuntimeSnapshot | null): boolean {
   const shell = snapshot?.shell && typeof snapshot.shell === "object"
     ? snapshot.shell as Record<string, unknown>
     : null;
@@ -1567,7 +1577,15 @@ function accountRuntimeNeedsIdentity(snapshot: RuntimeSnapshot | null): boolean 
   return identity?.linked === false;
 }
 
+function accountRuntimeNeedsIdentity(snapshot: RuntimeSnapshot | null): boolean {
+  const preparedIdentity = runtimeShellIdentityFromSnapshot(snapshot);
+  if (preparedIdentity.linked === true) return false;
+  return rawSnapshotNeedsIdentity(snapshot);
+}
+
 function accountRuntimeIdentityResolved(snapshot: RuntimeSnapshot | null): boolean {
+  const preparedIdentity = runtimeShellIdentityFromSnapshot(snapshot);
+  if (typeof preparedIdentity.linked === "boolean") return true;
   const shell = snapshot?.shell && typeof snapshot.shell === "object"
     ? snapshot.shell as Record<string, unknown>
     : null;
@@ -1747,7 +1765,8 @@ function localBrowserDevicePk(identity: Record<string, unknown> | null, deviceRe
 
 function localCachedNvrRuntimeContext(snapshot: RuntimeSnapshot | null): RuntimeServiceContext | null {
   const identity = localAccountIdentity();
-  const identityId = String(identity?.identityId || identity?.id || "").trim();
+  const snapshotIdentity = runtimeIdentityFromSnapshot(snapshot);
+  const identityId = String(identity?.identityId || identity?.id || snapshotIdentity.identityId || snapshotIdentity.id || "").trim();
   if (!identityId) return null;
   const deviceRecords = localStorageRecordList(ACCOUNT_DEVICE_CACHE_KEY);
   const candidates = [...deviceRecords, ...localHostedServiceRecordsFrom(deviceRecords), ...localGatewayHostedSnapshots()]
@@ -1762,7 +1781,8 @@ function localCachedNvrRuntimeContext(snapshot: RuntimeSnapshot | null): Runtime
     record = mergeNvrDirectoryRecords(record, candidate as ManagedApplianceRecord);
   }
   const gatewayPk = applianceGatewayPk(record);
-  const browserDevicePk = localBrowserDevicePk(identity, deviceRecords);
+  const browserDevicePk = localBrowserDevicePk(identity, deviceRecords)
+    || String(snapshotIdentity.devicePk || snapshotIdentity.device_pk || snapshotIdentity.browserDevicePk || "").trim();
   const discoveryScope = runtimeDiscoveryScopeFromRecord(record, snapshot, gatewayPk) || localGatewayExtraDiscoveryScope(gatewayPk);
   return {
     contextId: parseRuntimeContextId() || randomOpaqueId("nvr-context"),
@@ -1793,7 +1813,7 @@ async function waitForDirectEntryNvrServiceRecord(): Promise<{
   let snapshot = await currentRuntimeSnapshot();
   let record = directEntryNvrServiceRecord(snapshot);
   if (record) return { snapshot, record };
-  if (accountRuntimeNeedsIdentity(snapshot)) return { snapshot, record: null };
+  if (localCachedNvrRuntimeContext(snapshot)) return { snapshot, record: null };
 
   const deadline = Date.now() + DIRECT_ENTRY_ACCOUNT_HYDRATION_TIMEOUT_MS;
   let identityResolvedAt = 0;
@@ -1801,7 +1821,7 @@ async function waitForDirectEntryNvrServiceRecord(): Promise<{
     snapshot = await currentRuntimeSnapshot();
     record = directEntryNvrServiceRecord(snapshot);
     if (record) return { snapshot, record };
-    if (accountRuntimeNeedsIdentity(snapshot)) return { snapshot, record: null };
+    if (localCachedNvrRuntimeContext(snapshot)) return { snapshot, record: null };
     if (accountRuntimeIdentityResolved(snapshot)) {
       identityResolvedAt ||= Date.now();
       if (Date.now() - identityResolvedAt >= DIRECT_ENTRY_ACCOUNT_HYDRATED_SETTLE_MS) {
@@ -1815,6 +1835,8 @@ async function waitForDirectEntryNvrServiceRecord(): Promise<{
 }
 
 function runtimeIdentityFromSnapshot(snapshot: RuntimeSnapshot | null): Record<string, unknown> {
+  const preparedIdentity = runtimeShellIdentityFromSnapshot(snapshot);
+  if (preparedIdentity.linked === true) return preparedIdentity;
   const shell = snapshot?.shell && typeof snapshot.shell === "object"
     ? snapshot.shell as Record<string, unknown>
     : {};
@@ -1934,6 +1956,9 @@ function contextFromRuntimeRecord(record: ManagedApplianceRecord, snapshot: Runt
   const contextId = parseRuntimeContextId() || randomOpaqueId("nvr-context");
   const browserDevicePk = String(identity.devicePk || identity.device_pk || identity.browserDevicePk || "").trim();
   const discoveryScope = runtimeDiscoveryScopeFromRecord(record, snapshot, gatewayPk);
+  const hostFabric = record.hostFabric && typeof record.hostFabric === "object" && !Array.isArray(record.hostFabric)
+    ? record.hostFabric as Record<string, unknown>
+    : null;
   return {
     contextId,
     app: "nvr",
@@ -1944,7 +1969,13 @@ function contextFromRuntimeRecord(record: ManagedApplianceRecord, snapshot: Runt
     servicePk,
     service: "nvr",
     ...(discoveryScope ? { discoveryScope } : {}),
-    ...(record.hostFabric && typeof record.hostFabric === "object" ? { hostFabric: record.hostFabric as Record<string, unknown> } : {}),
+    ...(hostFabric ? { hostFabric } : {
+      legacyPathFallback: {
+        state: "legacyPathFallback",
+        reason: "runtime service catalog is missing host-fabric posture; using transition service directory",
+        sourceRefs: ["runtime.serviceCatalog", "runtime.managedAppliances"],
+      },
+    }),
     display: nvrDisplayFromRecord(record),
     createdAt: Date.now(),
     expiresAt: Date.now() + (10 * 60_000),
@@ -2960,7 +2991,7 @@ function nvrServiceCatalogBlockedReason(record: ManagedApplianceRecord): string 
   const fabric = record.hostFabric && typeof record.hostFabric === "object" && !Array.isArray(record.hostFabric)
     ? record.hostFabric as Record<string, unknown>
     : null;
-  if (!fabric) return "Security Cameras service is missing MSA host-fabric posture.";
+  if (!fabric) return "";
   const state = String(fabric.state || fabric.fulfillmentState || fabric.lifecycleState || "").trim().toLowerCase();
   const blockedReasons = Array.isArray(fabric.blockedReasons)
     ? fabric.blockedReasons.map((reason) => String(reason || "").trim()).filter(Boolean)

--- a/tests/runtime-projection.spec.ts
+++ b/tests/runtime-projection.spec.ts
@@ -15,6 +15,7 @@ type RuntimeHarnessOptions = {
   edgeConnected?: boolean;
   includeNvrService?: boolean;
   includeServiceCatalog?: boolean;
+  catalogLegacyFallback?: boolean;
   delayedServiceAfterSnapshotGets?: number;
   localAccountCacheFallback?: boolean;
   localAccountCacheSources?: boolean;
@@ -46,6 +47,7 @@ function runtimeSnapshot({
   edgeConnected = true,
   includeNvrService = true,
   includeServiceCatalog = includeNvrService,
+  catalogLegacyFallback = false,
 }: RuntimeHarnessOptions = {}) {
   const hasNvrService = linked && includeNvrService;
   const hasCatalogService = linked && includeServiceCatalog;
@@ -179,6 +181,13 @@ function runtimeSnapshot({
             associationHandoffRef: `handoff:gateway:${GATEWAY_PK}:initial-owner`,
             blockedReasons: [],
           },
+          ...(catalogLegacyFallback ? {
+            legacyPathFallback: {
+              state: "legacyPathFallback",
+              reason: "retained hosted-service cache used",
+              sourceRefs: ["runtime.shared.state.hostedGatewaySnapshots"],
+            },
+          } : {}),
         },
       ] : [],
     },
@@ -709,6 +718,30 @@ test("direct entry blocks legacy hosted records without service catalog posture"
   await expect(page.locator(".cameraTile")).toHaveCount(0);
   await expect(page.locator(".emptyState")).toContainText("Opening Security Cameras");
   await page.waitForTimeout(750);
+  const streamOpenCount = await page.evaluate(() => {
+    const probe = (window as Window & { __runtimeProbe?: { intents: Array<Record<string, unknown>> } }).__runtimeProbe;
+    return probe?.intents.filter((intent) => intent.type === "runtime.stream.open").length || 0;
+  });
+  expect(streamOpenCount).toBe(0);
+});
+
+test("direct entry blocks service catalog records marked as legacy fallback", async ({ page }) => {
+  await installRuntimeHarness(page, {
+    includeProjections: false,
+    includeNvrService: true,
+    includeServiceCatalog: true,
+    catalogLegacyFallback: true,
+    hostedCameraCount: 2,
+    hostedFacts: {
+      configuredSources: 2,
+      sources: ["reolink-ec-71-db-32-0a-8f", "xm-192-168-0-201"],
+    },
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator(".cameraTile")).toHaveCount(0);
+  await expect(page.locator(".emptyState")).toContainText("retained hosted-service cache used");
   const streamOpenCount = await page.evaluate(() => {
     const probe = (window as Window & { __runtimeProbe?: { intents: Array<Record<string, unknown>> } }).__runtimeProbe;
     return probe?.intents.filter((intent) => intent.type === "runtime.stream.open").length || 0;

--- a/tests/runtime-projection.spec.ts
+++ b/tests/runtime-projection.spec.ts
@@ -15,9 +15,13 @@ type RuntimeHarnessOptions = {
   edgeConnected?: boolean;
   includeNvrService?: boolean;
   includeServiceCatalog?: boolean;
+  forceServiceProjectionWhenUnlinked?: boolean;
   catalogLegacyFallback?: boolean;
+  catalogHostFabric?: Record<string, unknown> | false | null;
   delayedServiceAfterSnapshotGets?: number;
   localAccountCacheFallback?: boolean;
+  localAccountCacheDelayMs?: number;
+  localAccountCacheIdentity?: boolean;
   localAccountCacheSources?: boolean;
   pendingStreamRoute?: boolean;
   edgeAttachAuthorityWait?: boolean;
@@ -47,10 +51,20 @@ function runtimeSnapshot({
   edgeConnected = true,
   includeNvrService = true,
   includeServiceCatalog = includeNvrService,
+  forceServiceProjectionWhenUnlinked = false,
   catalogLegacyFallback = false,
+  catalogHostFabric,
 }: RuntimeHarnessOptions = {}) {
-  const hasNvrService = linked && includeNvrService;
-  const hasCatalogService = linked && includeServiceCatalog;
+  const serviceProjectionAllowed = linked || forceServiceProjectionWhenUnlinked;
+  const hasNvrService = serviceProjectionAllowed && includeNvrService;
+  const hasCatalogService = serviceProjectionAllowed && includeServiceCatalog;
+  const hostFabric = catalogHostFabric === undefined
+    ? {
+      state: "ready",
+      associationHandoffRef: `handoff:gateway:${GATEWAY_PK}:initial-owner`,
+      blockedReasons: [],
+    }
+    : catalogHostFabric;
   const projections = includeProjections ? {
     "nvr.health": projectionRecord("nvr.health", {
       nodePath: "health",
@@ -176,11 +190,7 @@ function runtimeSnapshot({
           hostGatewayPk: GATEWAY_PK,
           label: "Security Cameras",
           health: { status: "ready", configuredSources: 2 },
-          hostFabric: {
-            state: "ready",
-            associationHandoffRef: `handoff:gateway:${GATEWAY_PK}:initial-owner`,
-            blockedReasons: [],
-          },
+          ...(hostFabric && typeof hostFabric === "object" ? { hostFabric } : {}),
           ...(catalogLegacyFallback ? {
             legacyPathFallback: {
               state: "legacyPathFallback",
@@ -201,22 +211,24 @@ async function installRuntimeHarness(page: Page, options: RuntimeHarnessOptions 
   const delayedSnapshot = options.delayedServiceAfterSnapshotGets
     ? runtimeSnapshot({ ...options, includeNvrService: true })
     : null;
-  await page.addInitScript(({ snapshot, delayedSnapshot, delayedServiceAfterSnapshotGets, authorityPostures, earlyStreamAnswer, localAccountCacheFallback, localAccountCacheSources, pendingStreamRoute, edgeAttachAuthorityWait, adapterIceFailureAfterAnswer, mediaTransportProfileUnsupported, browserPk, gatewayPk, nvrServicePk }) => {
-    if (localAccountCacheFallback) {
+  await page.addInitScript(({ snapshot, delayedSnapshot, delayedServiceAfterSnapshotGets, authorityPostures, earlyStreamAnswer, localAccountCacheFallback, localAccountCacheDelayMs, localAccountCacheIdentity, localAccountCacheSources, pendingStreamRoute, edgeAttachAuthorityWait, adapterIceFailureAfterAnswer, mediaTransportProfileUnsupported, browserPk, gatewayPk, nvrServicePk }) => {
+    const seedLocalAccountCache = () => {
       const ts = Date.now();
       const includeSources = localAccountCacheSources !== false;
-      window.localStorage.setItem("swarm.identityCache", JSON.stringify({
-        ts,
-        records: [
-          {
-            identityId: "identity-001",
-            label: "operator",
-            devicePks: [browserPk, gatewayPk],
-            updatedAt: ts,
-            expiresAt: ts + 86_400_000,
-          },
-        ],
-      }));
+      if (localAccountCacheIdentity !== false) {
+        window.localStorage.setItem("swarm.identityCache", JSON.stringify({
+          ts,
+          records: [
+            {
+              identityId: "identity-001",
+              label: "operator",
+              devicePks: [browserPk, gatewayPk],
+              updatedAt: ts,
+              expiresAt: ts + 86_400_000,
+            },
+          ],
+        }));
+      }
       window.localStorage.setItem("swarm.deviceCache", JSON.stringify({
         ts,
         records: [
@@ -260,6 +272,14 @@ async function installRuntimeHarness(page: Page, options: RuntimeHarnessOptions 
       window.localStorage.setItem("constitute.gateway.extraZones", JSON.stringify({
         [gatewayPk]: ["zone-a"],
       }));
+    };
+    if (localAccountCacheFallback) {
+      const delayMs = Math.max(0, Number(localAccountCacheDelayMs || 0));
+      if (delayMs > 0) {
+        window.setTimeout(seedLocalAccountCache, delayMs);
+      } else {
+        seedLocalAccountCache();
+      }
     }
 
     const state = {
@@ -517,6 +537,8 @@ async function installRuntimeHarness(page: Page, options: RuntimeHarnessOptions 
     delayedServiceAfterSnapshotGets: options.delayedServiceAfterSnapshotGets || 0,
     earlyStreamAnswer: options.earlyStreamAnswer === true ? true : options.earlyStreamAnswer === "frameAfterResponse" ? "frameAfterResponse" : false,
     localAccountCacheFallback: options.localAccountCacheFallback === true,
+    localAccountCacheDelayMs: options.localAccountCacheDelayMs || 0,
+    localAccountCacheIdentity: options.localAccountCacheIdentity !== false,
     localAccountCacheSources: options.localAccountCacheSources !== false,
     authorityPostures: options.authorityPostures || [],
     pendingStreamRoute: options.pendingStreamRoute === true,
@@ -747,6 +769,50 @@ test("direct entry blocks service catalog records marked as legacy fallback", as
     return probe?.intents.filter((intent) => intent.type === "runtime.stream.open").length || 0;
   });
   expect(streamOpenCount).toBe(0);
+});
+
+test("direct entry uses current service catalog while host-fabric posture hydrates", async ({ page }) => {
+  await installRuntimeHarness(page, {
+    includeProjections: false,
+    includeNvrService: true,
+    includeServiceCatalog: true,
+    catalogHostFabric: false,
+    hostedCameraCount: 2,
+    hostedFacts: {
+      configuredSources: 2,
+      sources: ["reolink-ec-71-db-32-0a-8f", "xm-192-168-0-201"],
+      cameraDevices: [
+        {
+          sourceId: "reolink-ec-71-db-32-0a-8f",
+          name: "Carport",
+          enabled: true,
+          ptzCapable: true,
+        },
+        {
+          sourceId: "xm-192-168-0-201",
+          name: "Front Door",
+          enabled: true,
+          ptzCapable: false,
+        },
+      ],
+    },
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator(".cameraTile")).toHaveCount(2);
+  await expect(page.locator(".cameraTitle")).toContainText(["Carport", "Front Door"]);
+  await expect(page.locator("body")).not.toContainText("missing MSA host-fabric posture");
+  await expect.poll(async () => page.evaluate(() => {
+    const probe = (window as Window & { __runtimeProbe?: { intents: Array<Record<string, unknown>>; statuses: Array<Record<string, unknown>> } }).__runtimeProbe;
+    return {
+      streamOpenCount: probe?.intents.filter((intent) => intent.type === "runtime.stream.open").length || 0,
+      degraded: probe?.statuses.some((status) => String(status.reason || "").includes("missing host-fabric posture")) || false,
+    };
+  })).toEqual({
+    streamOpenCount: 1,
+    degraded: true,
+  });
 });
 
 test("direct entry leaves stream route fields to runtime when hosted facts carry identity-local zones", async ({ page }) => {
@@ -995,13 +1061,47 @@ test("direct entry without linked identity stays in prepared account-required st
 
   await page.goto("/");
 
-  await expect(page.locator(".emptyState")).toContainText("Account Required");
+  await expect(page.locator(".emptyState")).toContainText("Account Required", { timeout: 20_000 });
   await expect(page.locator(".emptyState")).toContainText("Open Account Center");
   const queued = await page.evaluate(() => {
     const probe = (window as Window & { __runtimeProbe?: { frames: Array<Record<string, unknown>> } }).__runtimeProbe;
     return probe?.frames.length || 0;
   });
   expect(queued).toBe(0);
+});
+
+test("direct entry waits for retained account cache while raw snapshot is unlinked", async ({ page }) => {
+  await installRuntimeHarness(page, {
+    linked: false,
+    localAccountCacheFallback: true,
+    localAccountCacheDelayMs: 1_000,
+    authorityPostures: [{ state: "ready", ready: true, devicePk: BROWSER_PK }],
+  });
+
+  await page.goto("/");
+
+  await expect.poll(async () => page.evaluate(() => {
+    const probe = (window as Window & { __runtimeProbe?: { intents: Array<Record<string, unknown>> } }).__runtimeProbe;
+    return Boolean(probe?.intents.find((intent) => intent.type === "runtime.stream.open"));
+  })).toBe(true);
+  await expect(page.locator("body")).not.toContainText("Account Required");
+});
+
+test("direct entry trusts prepared read-model identity over raw unlinked snapshot shell", async ({ page }) => {
+  await installRuntimeHarness(page, {
+    linked: false,
+    forceServiceProjectionWhenUnlinked: true,
+    localAccountCacheFallback: true,
+    authorityPostures: [{ state: "ready", ready: true, devicePk: BROWSER_PK }],
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator("body")).not.toContainText("Account Required");
+  await expect.poll(async () => page.evaluate(() => {
+    const probe = (window as Window & { __runtimeProbe?: { intents: Array<Record<string, unknown>> } }).__runtimeProbe;
+    return Boolean(probe?.intents.find((intent) => intent.type === "runtime.stream.open"));
+  })).toBe(true);
 });
 
 test("direct entry uses retained account cache when account worker snapshot is unlinked", async ({ page }) => {
@@ -1040,6 +1140,25 @@ test("direct entry uses retained account cache when account worker snapshot is u
     }),
   }));
   expect((edgeAttach as Record<string, unknown>).memberRef).toBeUndefined();
+});
+
+test("direct entry uses runtime identity with retained device cache when local identity cache is empty", async ({ page }) => {
+  await installRuntimeHarness(page, {
+    includeNvrService: false,
+    includeServiceCatalog: false,
+    includeProjections: false,
+    localAccountCacheFallback: true,
+    localAccountCacheIdentity: false,
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator("body")).not.toContainText("Account Required");
+  await expect(page.locator(".cameraTile")).toHaveCount(2);
+  await expect.poll(async () => page.evaluate(() => {
+    const probe = (window as Window & { __runtimeProbe?: { intents: Array<Record<string, unknown>> } }).__runtimeProbe;
+    return Boolean(probe?.intents.find((intent) => intent.type === "runtime.stream.open"));
+  })).toBe(true);
 });
 
 test("direct entry opens auto preview when retained account cache only has camera count", async ({ page }) => {

--- a/tests/runtime-projection.spec.ts
+++ b/tests/runtime-projection.spec.ts
@@ -14,6 +14,7 @@ type RuntimeHarnessOptions = {
   edgeZoneScope?: Record<string, unknown> | null;
   edgeConnected?: boolean;
   includeNvrService?: boolean;
+  includeServiceCatalog?: boolean;
   delayedServiceAfterSnapshotGets?: number;
   localAccountCacheFallback?: boolean;
   localAccountCacheSources?: boolean;
@@ -44,8 +45,10 @@ function runtimeSnapshot({
   edgeZoneScope = { zoneId: "zone-a", privacy: "rawIds", ttl: 30, maxHops: 2 },
   edgeConnected = true,
   includeNvrService = true,
+  includeServiceCatalog = includeNvrService,
 }: RuntimeHarnessOptions = {}) {
   const hasNvrService = linked && includeNvrService;
+  const hasCatalogService = linked && includeServiceCatalog;
   const projections = includeProjections ? {
     "nvr.health": projectionRecord("nvr.health", {
       nodePath: "health",
@@ -164,13 +167,18 @@ function runtimeSnapshot({
     } : { owned: [], granted: [], discoverable: [] },
     serviceCatalog: {
       updatedAt: Date.now(),
-      services: hasNvrService ? [
+      services: hasCatalogService ? [
         {
           service: "nvr",
           servicePk: NVR_SERVICE_PK,
           hostGatewayPk: GATEWAY_PK,
           label: "Security Cameras",
           health: { status: "ready", configuredSources: 2 },
+          hostFabric: {
+            state: "ready",
+            associationHandoffRef: `handoff:gateway:${GATEWAY_PK}:initial-owner`,
+            blockedReasons: [],
+          },
         },
       ] : [],
     },
@@ -682,6 +690,30 @@ test("direct entry materializes gateway-hosted camera facts before projection re
   await expect(page.locator(".cameraTitle")).toContainText(["Carport", "Front Door"]);
   await expect(page.locator("#popServices")).toContainText("Security Cameras (2 cameras)");
   await expect(page.locator(".emptyState")).toHaveCount(0);
+});
+
+test("direct entry blocks legacy hosted records without service catalog posture", async ({ page }) => {
+  await installRuntimeHarness(page, {
+    includeProjections: false,
+    includeNvrService: true,
+    includeServiceCatalog: false,
+    hostedCameraCount: 2,
+    hostedFacts: {
+      configuredSources: 2,
+      sources: ["reolink-ec-71-db-32-0a-8f", "xm-192-168-0-201"],
+    },
+  });
+
+  await page.goto("/");
+
+  await expect(page.locator(".cameraTile")).toHaveCount(0);
+  await expect(page.locator(".emptyState")).toContainText("Opening Security Cameras");
+  await page.waitForTimeout(750);
+  const streamOpenCount = await page.evaluate(() => {
+    const probe = (window as Window & { __runtimeProbe?: { intents: Array<Record<string, unknown>> } }).__runtimeProbe;
+    return probe?.intents.filter((intent) => intent.type === "runtime.stream.open").length || 0;
+  });
+  expect(streamOpenCount).toBe(0);
 });
 
 test("direct entry leaves stream route fields to runtime when hosted facts carry identity-local zones", async ({ page }) => {

--- a/tests/source-convergence.test.js
+++ b/tests/source-convergence.test.js
@@ -331,6 +331,8 @@ test("first-party account centers use shared runtime read models and account-onl
   assert.match(gatewayRuntimeModel, /deriveRuntimeMaterializationPosture/);
   assert.match(logging, /prepareRuntimeReadModel/);
   assert.match(nvr, /prepareRuntimeReadModel/);
+  assert.match(nvr, /runtimeReadModel\.target/);
+  assert.match(nvr, /runtimeReadModel\.fabric/);
   assert.match(account, /runtimeResourceStatus/);
   assert.match(gatewayRuntimeModel, /Resource posture/);
   assert.match(logging, /runtimeReadModel\.shell/);


### PR DESCRIPTION
Moves NVR UI to shared service host-fabric posture, media fulfillment evidence, and runtime read-model consumption.\n\nProof: local NVR UI tests/build, browser, convergence, affected, aggregate, and 10-minute media/resource proof passed.